### PR TITLE
Fix CLI usage examples to match actual argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Here's how to transpile, compile, and run an Occam program:
 go build -o occam2go
 
 # 2. Transpile an Occam file to Go
-./occam2go examples/print.occ -o output.go
+./occam2go -o output.go examples/print.occ
 
 # 3. Compile the generated Go code
 go build -o output output.go
@@ -41,7 +41,7 @@ go build -o output output.go
 Or as a one-liner to see the output immediately:
 
 ```bash
-./occam2go examples/print.occ -o output.go && go run output.go
+./occam2go -o output.go examples/print.occ && go run output.go
 ```
 
 ## Example


### PR DESCRIPTION
## Summary
- Fix README examples that showed `./occam2go <input> -o <output>` to use the correct order `./occam2go -o <output> <input>`

Fixes #1

## Test plan
- [x] Verified the two affected usage examples now match the actual CLI argument order

🤖 Generated with [Claude Code](https://claude.com/claude-code)