### PR TITLE
Add script to clone KRoC repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 
 # Generated Go files from examples
 examples/*.go
+
+# External repositories
+kroc/

--- a/scripts/clone-kroc.sh
+++ b/scripts/clone-kroc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Clone the KRoC (Kent Retargetable occam Compiler) repository.
+# This provides the occam "course" standard library source code
+# needed for transpiling programs that use it.
+
+set -e
+
+REPO_URL="https://github.com/concurrency/kroc.git"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+TARGET_DIR="$PROJECT_DIR/kroc"
+
+if [ -d "$TARGET_DIR" ]; then
+    echo "kroc/ already exists. To re-clone, remove it first:"
+    echo "  rm -rf $TARGET_DIR"
+    exit 1
+fi
+
+echo "Cloning KRoC repository into kroc/..."
+git clone "$REPO_URL" "$TARGET_DIR"
+echo "Done."


### PR DESCRIPTION
## Summary
- Adds `scripts/clone-kroc.sh` to clone the [concurrency/kroc](https://github.com/concurrency/kroc) repository, which contains the occam course library source code
- Adds `kroc/` to `.gitignore` to keep the cloned repo out of version control
- Prepares for future work on supporting the occam course module (standard library)

## Test plan
- [x] Run `./scripts/clone-kroc.sh` — clones successfully into `kroc/`
- [x] Run it again — exits with a message that `kroc/` already exists
- [x] Verify `git status` does not show `kroc/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)