### PR TITLE
Add preprocessor, module generator, and #INCLUDE support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - **CASE** — Pattern matching with multiple cases and ELSE branch
 - **ALT** — Channel alternation, maps to Go `select`; supports boolean guards and timer timeouts
 - **SKIP** — No-op process
+- **STOP** — Error + deadlock
 
 ### Data Types & Declarations
 - **INT, BYTE, BOOL, REAL, REAL32, REAL64** — Scalar types (REAL/REAL64 map to float64, REAL32 maps to float32)
@@ -17,6 +18,7 @@
 - **Arrays** — `[n]TYPE arr:` with index expressions
 - **Channels** — `CHAN OF TYPE c:` with send (`!`) and receive (`?`)
 - **Channel arrays** — `[n]CHAN OF TYPE cs:` with indexed send/receive and `[]CHAN OF TYPE` proc params
+- **Channel direction** — `CHAN OF INT c?` (receive-only) and `CHAN OF INT c!` (send-only)
 - **Timers** — `TIMER tim:` with reads and `AFTER` expressions
 
 ### Procedures & Functions
@@ -30,21 +32,77 @@
 - **Arithmetic** — `+`, `-`, `*`, `/`, `\` (modulo)
 - **Comparison** — `=`, `<>`, `<`, `>`, `<=`, `>=`
 - **Logical** — `AND`, `OR`, `NOT`
+- **Bitwise** — `/\`, `\/`, `><`, `~`, `<<`, `>>`
 - **AFTER** — As boolean expression (maps to `>`)
 - **Parenthesized expressions**
 - **Array indexing** — `arr[i]`, `arr[expr]`
-- **String literals** — Double-quoted strings, usable in expressions, assignments, and channel communication
+- **String literals** — Double-quoted strings
+- **Type conversions** — `INT expr`, `BYTE expr`, `REAL32 expr`, `REAL64 expr`
+
+### Protocols
+- **Simple** — `PROTOCOL SIG IS INT` (type alias)
+- **Sequential** — `PROTOCOL PAIR IS INT ; BYTE` (struct)
+- **Variant** — `PROTOCOL MSG CASE tag; TYPE ...` (interface + concrete types)
+
+### Records
+- **RECORD** — Struct types with field access via bracket syntax (`p[x]`)
+
+### Preprocessor
+- **`#IF` / `#ELSE` / `#ENDIF`** — Conditional compilation with `TRUE`, `FALSE`, `DEFINED()`, `NOT`, equality
+- **`#DEFINE`** — Symbol definition
+- **`#INCLUDE`** — File inclusion with search paths and include guards
+- **`#COMMENT` / `#PRAGMA` / `#USE`** — Ignored (blank lines)
+- **Predefined symbols** — `TARGET.BITS.PER.WORD = 64`
+
+### Tooling
+- **gen-module** — Generate `.module` files from KRoC SConscript build files
 
 ---
 
 ## Not Yet Implemented
 
-### Language Constructs
+### Required for course.module
+
+These features are needed to transpile the KRoC course module (`kroc/modules/course/libsrc/`), listed roughly in order of priority. Features used across many course module files are marked with frequency.
+
+| Feature | Notes | Used in |
+|---------|-------|---------|
+| **Abbreviations** | `VAL INT x IS 1:`, `VAL BYTE ch IS 'A':` — named constants. The most pervasive missing feature. | consts.inc, all .occ files |
+| **`CHAN BYTE` shorthand** | `CHAN BYTE out!` without `OF`. KRoC allows omitting `OF` for channel types. | all .occ files |
+| **`SIZE` operator** | `SIZE s` returns length of an array/string. | utils.occ, string.occ, file_in.occ, stringbuf.occ |
+| **Open array params** | `VAL []BYTE s`, `[]BYTE s` — unsized array/slice parameters for PROCs and FUNCTIONs. (`[]CHAN OF T` is already supported.) | utils.occ, string.occ, file_in.occ, stringbuf.occ |
+| **BYTE literals** | `'A'`, `'0'`, `' '` — single-quoted character literals. | utils.occ, file_in.occ, string.occ |
+| **Occam escape sequences** | `*n` (newline), `*c` (carriage return), `*t` (tab) — occam uses `*` not `\` for escapes in strings and byte literals. | utils.occ, file_in.occ |
+| **PROC terminator `:` ** | Standalone `:` at the end of a PROC/FUNCTION body (KRoC style). | all .occ files |
+| **Nested PROCs/FUNCTIONs** | Local PROC/FUNCTION definitions inside a PROC body. | float_io.occ, stringbuf.occ |
+| **Multi-result FUNCTIONs** | `INT, INT FUNCTION f(...)` returning multiple values via `RESULT a, b`. | random.occ, utils.occ, string.occ, float_io.occ |
+| **Replicated IF** | `IF i = 0 FOR n` — replicated conditional. | utils.occ, file_in.occ, string.occ, float_io.occ |
+| **Hex integer literals** | `#FF`, `#80000000` — prefixed with `#`. | float_io.occ, stringbuf.occ |
+| **Checked arithmetic** | `TIMES`, `PLUS`, `MINUS` — modular (wrapping) arithmetic operators. | demo_cycles.occ, random.occ, utils.occ |
+| **`MOSTNEG INT`** | Most-negative integer constant. | utils.occ |
+| **`INITIAL` declarations** | `INITIAL INT i IS 0:` — mutable variable with initial value. | stringbuf.occ |
+| **Array slices** | `[a FROM n FOR m]` — sub-array references. | string.occ, stringbuf.occ, float_io.occ |
+| **Replicator STEP** | `SEQ i = n FOR m STEP -1` — step value in replicators. | stringbuf.occ |
+| **Multi-assignment** | `a, b := x, y` — parallel assignment to multiple variables. | stringbuf.occ, utils.occ |
+
+### Required for shared_screen module (extends course module)
+
+| Feature | Notes | Used in |
+|---------|-------|---------|
+| **`DATA TYPE X IS TYPE:`** | Simple type alias (e.g. `DATA TYPE COLOUR IS BYTE:`). | shared_screen.inc |
+| **`DATA TYPE X RECORD`** | Alternative record syntax (vs current `RECORD X`). | shared_screen.inc |
+| **Counted array protocol** | `BYTE::[]BYTE` — length-prefixed array in protocols. | shared_screen.inc, shared_screen.occ |
+| **`RESULT` param qualifier** | `RESULT INT len` on PROC params (output-only, like a write-only reference). | float_io.occ |
+
+### Other language features
 
 | Feature | Notes |
 |---------|-------|
-| **Abbreviations** | `name IS expr:` and `VAL name IS expr:` for aliasing. Only partially used in FUNCTION IS form. |
 | **PRI ALT / PRI PAR** | Priority variants of ALT and PAR. |
-| **Complex ALT guards** | Only simple boolean + channel guards work currently. |
 | **PLACED PAR** | Assigning processes to specific hardware. |
 | **PORT OF** | Hardware port mapping. |
+| **`RETYPES`** | Type punning / reinterpret cast (`VAL INT X RETYPES X :`). Used in float_io.occ. |
+| **`CAUSEERROR ()`** | Built-in error-raising primitive. Used in float_io.occ. |
+| **Transputer intrinsics** | `LONGPROD`, `LONGDIV`, `LONGSUM`, `LONGDIFF`, `NORMALISE`, `SHIFTLEFT`, `SHIFTRIGHT`. Used in float_io.occ. |
+| **`VAL []BYTE` abbreviations** | `VAL []BYTE cmap IS "0123456789ABCDEF":` — named string constants. |
+| **`#PRAGMA DEFINED`** | Compiler hint to suppress definedness warnings. Can be ignored. |

--- a/codegen/e2e_test.go
+++ b/codegen/e2e_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/codeassociates/occam2go/lexer"
 	"github.com/codeassociates/occam2go/parser"
+	"github.com/codeassociates/occam2go/preproc"
 )
 
 // transpileCompileRun takes Occam source, transpiles to Go, compiles, runs,
@@ -1301,6 +1302,25 @@ SEQ
 	}
 }
 
+// transpileCompileRunWithPreproc takes an occam file path, preprocesses it,
+// then transpiles, compiles, and runs.
+func transpileCompileRunFromFile(t *testing.T, mainFile string, includePaths []string) string {
+	t.Helper()
+
+	pp := preproc.New(preproc.WithIncludePaths(includePaths))
+	expanded, err := pp.ProcessFile(mainFile)
+	if err != nil {
+		t.Fatalf("preprocessor error: %v", err)
+	}
+	if len(pp.Errors()) > 0 {
+		for _, e := range pp.Errors() {
+			t.Errorf("preprocessor warning: %s", e)
+		}
+	}
+
+	return transpileCompileRun(t, expanded)
+}
+
 func TestE2E_ChanDirParam(t *testing.T) {
 	occam := `PROC producer(CHAN OF INT output!)
   output ! 42
@@ -1318,6 +1338,75 @@ SEQ
     consumer(c)
 `
 	output := transpileCompileRun(t, occam)
+	expected := "42\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+// --- Preprocessor E2E tests ---
+
+func TestE2E_IncludeConstants(t *testing.T) {
+	// Test #INCLUDE of a constants file and using the constant in a program
+	tmpDir := t.TempDir()
+
+	// Create a constants file with a function
+	constsContent := "INT FUNCTION magic(VAL INT n)\n  IS n * 2\n"
+	os.WriteFile(filepath.Join(tmpDir, "consts.inc"), []byte(constsContent), 0644)
+
+	// Create main file that includes the constants
+	mainContent := `#INCLUDE "consts.inc"
+SEQ
+  print.int(magic(21))
+`
+	mainFile := filepath.Join(tmpDir, "main.occ")
+	os.WriteFile(mainFile, []byte(mainContent), 0644)
+
+	output := transpileCompileRunFromFile(t, mainFile, nil)
+	expected := "42\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_IfFalseExcludes(t *testing.T) {
+	// Test that #IF FALSE excludes code from compilation
+	tmpDir := t.TempDir()
+
+	mainContent := `SEQ
+  print.int(1)
+#IF FALSE
+  THIS IS INVALID OCCAM AND SHOULD NOT BE PARSED
+#ENDIF
+`
+	mainFile := filepath.Join(tmpDir, "main.occ")
+	os.WriteFile(mainFile, []byte(mainContent), 0644)
+
+	output := transpileCompileRunFromFile(t, mainFile, nil)
+	expected := "1\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_IncludeGuardPreventsDouble(t *testing.T) {
+	// Test that include guards prevent double-inclusion of declarations
+	tmpDir := t.TempDir()
+
+	// Create a guarded module with a function
+	modContent := "#IF NOT (DEFINED (TEST.MODULE))\n#DEFINE TEST.MODULE\nINT FUNCTION doubled(VAL INT x)\n  IS x * 2\n#ENDIF\n"
+	os.WriteFile(filepath.Join(tmpDir, "test.module"), []byte(modContent), 0644)
+
+	// Include it twice — should work thanks to guards
+	mainContent := `#INCLUDE "test.module"
+#INCLUDE "test.module"
+SEQ
+  print.int(doubled(21))
+`
+	mainFile := filepath.Join(tmpDir, "main.occ")
+	os.WriteFile(mainFile, []byte(mainContent), 0644)
+
+	output := transpileCompileRunFromFile(t, mainFile, nil)
 	expected := "42\n"
 	if output != expected {
 		t.Errorf("expected %q, got %q", expected, output)

--- a/examples/include_demo.occ
+++ b/examples/include_demo.occ
@@ -1,0 +1,14 @@
+-- Demonstrates using #INCLUDE to import a module.
+--
+-- Transpile and run:
+--   ./occam2go -I examples -o include_demo.go examples/include_demo.occ
+--   go run include_demo.go
+--
+-- The -I flag tells the preprocessor where to search for included files.
+
+#INCLUDE "mathlib.module"
+
+SEQ
+  print.int(abs(0 - 42))
+  print.int(max(10, 20))
+  print.int(min(10, 20))

--- a/examples/mathlib.module
+++ b/examples/mathlib.module
@@ -1,0 +1,38 @@
+-- A small utility module demonstrating #INCLUDE with include guards.
+-- This is a self-contained example; it does not depend on the KRoC
+-- course module (which uses occam features not yet supported by occam2go).
+
+#IF NOT (DEFINED (MATHLIB.MODULE))
+#DEFINE MATHLIB.MODULE
+
+INT FUNCTION abs(VAL INT x)
+  INT result:
+  VALOF
+    IF
+      x < 0
+        result := 0 - x
+      TRUE
+        result := x
+    RESULT result
+
+INT FUNCTION max(VAL INT a, VAL INT b)
+  INT result:
+  VALOF
+    IF
+      a > b
+        result := a
+      TRUE
+        result := b
+    RESULT result
+
+INT FUNCTION min(VAL INT a, VAL INT b)
+  INT result:
+  VALOF
+    IF
+      a < b
+        result := a
+      TRUE
+        result := b
+    RESULT result
+
+#ENDIF

--- a/main.go
+++ b/main.go
@@ -4,21 +4,44 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/codeassociates/occam2go/codegen"
 	"github.com/codeassociates/occam2go/lexer"
+	"github.com/codeassociates/occam2go/modgen"
 	"github.com/codeassociates/occam2go/parser"
+	"github.com/codeassociates/occam2go/preproc"
 )
 
 const version = "0.1.0"
 
+// multiFlag allows a flag to be specified multiple times (e.g. -I path1 -I path2).
+type multiFlag []string
+
+func (f *multiFlag) String() string { return strings.Join(*f, ", ") }
+func (f *multiFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
 func main() {
+	// Check for subcommand before parsing flags
+	if len(os.Args) >= 2 && os.Args[1] == "gen-module" {
+		genModuleCmd(os.Args[2:])
+		return
+	}
+
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	outputFile := flag.String("o", "", "Output file (default: stdout)")
+	var includePaths multiFlag
+	flag.Var(&includePaths, "I", "Include search path (repeatable)")
+	var defines multiFlag
+	flag.Var(&defines, "D", "Predefined symbol (repeatable)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "occam2go - An Occam to Go transpiler\n\n")
-		fmt.Fprintf(os.Stderr, "Usage: %s [options] <input.occ>\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [options] <input.occ>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "       %s gen-module [-o output] <SConscript>\n\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 	}
@@ -38,15 +61,35 @@ func main() {
 
 	inputFile := args[0]
 
-	// Read input file
-	input, err := os.ReadFile(inputFile)
+	// Build defines map
+	defs := map[string]string{}
+	for _, d := range defines {
+		if idx := strings.Index(d, "="); idx >= 0 {
+			defs[d[:idx]] = d[idx+1:]
+		} else {
+			defs[d] = ""
+		}
+	}
+
+	// Preprocess
+	pp := preproc.New(
+		preproc.WithIncludePaths(includePaths),
+		preproc.WithDefines(defs),
+	)
+	expanded, err := pp.ProcessFile(inputFile)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading file: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Preprocessor error: %s\n", err)
 		os.Exit(1)
+	}
+	if len(pp.Errors()) > 0 {
+		fmt.Fprintf(os.Stderr, "Preprocessor warnings:\n")
+		for _, e := range pp.Errors() {
+			fmt.Fprintf(os.Stderr, "  %s\n", e)
+		}
 	}
 
 	// Lex
-	l := lexer.New(string(input))
+	l := lexer.New(expanded)
 
 	// Parse
 	p := parser.New(l)
@@ -65,6 +108,57 @@ func main() {
 	output := gen.Generate(program)
 
 	// Write output
+	if *outputFile != "" {
+		err := os.WriteFile(*outputFile, []byte(output), 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing file: %s\n", err)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Print(output)
+	}
+}
+
+func genModuleCmd(args []string) {
+	fs := flag.NewFlagSet("gen-module", flag.ExitOnError)
+	outputFile := fs.String("o", "", "Output file (default: stdout)")
+	moduleName := fs.String("name", "", "Module guard name (default: derived from library name)")
+	fs.Parse(args)
+
+	if fs.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: occam2go gen-module [-o output] [-name GUARD] <SConscript>\n")
+		os.Exit(1)
+	}
+
+	sconscriptFile := fs.Arg(0)
+	data, err := os.ReadFile(sconscriptFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading SConscript: %s\n", err)
+		os.Exit(1)
+	}
+
+	libs := modgen.ParseSConscript(string(data))
+	if len(libs) == 0 {
+		fmt.Fprintf(os.Stderr, "No OccamLibrary found in %s\n", sconscriptFile)
+		os.Exit(1)
+	}
+
+	// Use first library by default
+	lib := libs[0]
+
+	// Derive module name from library name if not specified
+	guard := *moduleName
+	if guard == "" {
+		// course.lib → COURSE.MODULE
+		name := lib.Name
+		if idx := strings.LastIndex(name, "."); idx >= 0 {
+			name = name[:idx]
+		}
+		guard = strings.ToUpper(name) + ".MODULE"
+	}
+
+	output := modgen.GenerateModule(lib, guard)
+
 	if *outputFile != "" {
 		err := os.WriteFile(*outputFile, []byte(output), 0644)
 		if err != nil {

--- a/modgen/modgen.go
+++ b/modgen/modgen.go
@@ -1,0 +1,125 @@
+// Package modgen generates .module files from KRoC SConscript build files.
+// It parses the Python-based SConscript to extract source file lists and
+// OccamLibrary calls, then produces an occam module file with include guards.
+package modgen
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Library represents an OccamLibrary extracted from SConscript.
+type Library struct {
+	Name     string   // e.g. "course.lib"
+	Sources  []string // source files
+	Includes []string // --include files from OCCBUILDFLAGS
+	Needs    []string // --need dependencies from OCCBUILDFLAGS
+}
+
+// ParseSConscript parses a SConscript file's content and extracts library definitions.
+func ParseSConscript(content string) []Library {
+	vars := extractSplitVars(content)
+	return extractLibraries(content, vars)
+}
+
+// GenerateModule creates a .module file from a Library.
+// moduleName is the guard symbol (e.g. "COURSE.MODULE").
+func GenerateModule(lib Library, moduleName string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "#IF NOT (DEFINED (%s))\n", moduleName)
+	fmt.Fprintf(&b, "#DEFINE %s\n", moduleName)
+
+	// Include files from OCCBUILDFLAGS first
+	for _, inc := range lib.Includes {
+		fmt.Fprintf(&b, "#INCLUDE \"%s\"\n", inc)
+	}
+
+	// Then source files
+	for _, src := range lib.Sources {
+		fmt.Fprintf(&b, "#INCLUDE \"%s\"\n", src)
+	}
+
+	b.WriteString("#ENDIF\n")
+	return b.String()
+}
+
+// splitVarRe matches: varname = Split('''...''') or Split("""...""")
+var splitVarRe = regexp.MustCompile(`(\w+)\s*=\s*Split\(\s*(?:'''|""")([^'"]*)(?:'''|""")\s*\)`)
+
+// extractSplitVars finds all variable = Split('''...''') assignments.
+func extractSplitVars(content string) map[string][]string {
+	vars := map[string][]string{}
+	for _, m := range splitVarRe.FindAllStringSubmatch(content, -1) {
+		name := m[1]
+		files := splitWhitespace(m[2])
+		vars[name] = files
+	}
+	return vars
+}
+
+// libCallRe matches OccamLibrary calls (both direct and via return).
+// Captures: library name, source variable, and optional OCCBUILDFLAGS.
+var libCallRe = regexp.MustCompile(
+	`(?:local\.)?OccamLibrary\(\s*` +
+		`['"]([^'"]+)['"]\s*,\s*` + // library name
+		`(\w+)\s*` + // source variable
+		`(?:,[^)]*?)?\)`, // optional extra args
+)
+
+// flagsRe extracts OCCBUILDFLAGS value.
+var flagsRe = regexp.MustCompile(`OCCBUILDFLAGS\s*=\s*['"]([^'"]+)['"]`)
+
+func extractLibraries(content string, vars map[string][]string) []Library {
+	var libs []Library
+
+	for _, m := range libCallRe.FindAllStringSubmatch(content, -1) {
+		lib := Library{
+			Name: m[1],
+		}
+
+		srcVar := m[2]
+		if files, ok := vars[srcVar]; ok {
+			lib.Sources = files
+		}
+
+		// Look for OCCBUILDFLAGS in the full match
+		fullMatch := m[0]
+		if fm := flagsRe.FindStringSubmatch(fullMatch); fm != nil {
+			parseFlags(fm[1], &lib)
+		}
+
+		libs = append(libs, lib)
+	}
+
+	return libs
+}
+
+// parseFlags extracts --include and --need values from OCCBUILDFLAGS.
+func parseFlags(flags string, lib *Library) {
+	parts := strings.Fields(flags)
+	for i := 0; i < len(parts); i++ {
+		switch parts[i] {
+		case "--include":
+			if i+1 < len(parts) {
+				lib.Includes = append(lib.Includes, parts[i+1])
+				i++
+			}
+		case "--need":
+			if i+1 < len(parts) {
+				lib.Needs = append(lib.Needs, parts[i+1])
+				i++
+			}
+		}
+	}
+}
+
+func splitWhitespace(s string) []string {
+	var result []string
+	for _, f := range strings.Fields(s) {
+		if f != "" {
+			result = append(result, f)
+		}
+	}
+	return result
+}

--- a/modgen/modgen_test.go
+++ b/modgen/modgen_test.go
@@ -1,0 +1,171 @@
+package modgen
+
+import (
+	"strings"
+	"testing"
+)
+
+const courseSConscript = `Import('env')
+local = env.Clone()
+
+course_lib_srcs = Split('''
+    utils.occ
+    string.occ
+    demo_cycles.occ
+    demo_nets.occ
+    file_in.occ
+    float_io.occ
+    random.occ
+    ''')
+
+shared_screen_lib_srcs = Split('''
+    shared_screen.occ
+    ''')
+shared_screen_lib_objs = \
+        [local.OccamObject(f, INCPATH='.') for f in shared_screen_lib_srcs]
+
+
+
+course_lib = local.OccamLibrary(
+        'course.lib',
+        course_lib_srcs,
+        INCPATH='.',
+        OCCBUILDFLAGS='--include consts.inc')
+
+def mk_shared_screen(lib_name):
+    return local.OccamLibrary(
+            lib_name,
+            shared_screen_lib_objs,
+            INCPATH='.',
+            OCCBUILDFLAGS='--need course --include shared_screen.inc')
+
+sharedscreen_lib = mk_shared_screen('shared_screen.lib')
+# Build ss.lib too for backwards compatibility.
+mk_shared_screen('ss.lib')
+`
+
+func TestParseSConscriptCourseSources(t *testing.T) {
+	libs := ParseSConscript(courseSConscript)
+	if len(libs) == 0 {
+		t.Fatal("expected at least one library")
+	}
+
+	// Find course.lib
+	var courseLib *Library
+	for i := range libs {
+		if libs[i].Name == "course.lib" {
+			courseLib = &libs[i]
+			break
+		}
+	}
+	if courseLib == nil {
+		t.Fatal("expected to find course.lib")
+	}
+
+	expectedSources := []string{"utils.occ", "string.occ", "demo_cycles.occ", "demo_nets.occ", "file_in.occ", "float_io.occ", "random.occ"}
+	if len(courseLib.Sources) != len(expectedSources) {
+		t.Fatalf("expected %d sources, got %d: %v", len(expectedSources), len(courseLib.Sources), courseLib.Sources)
+	}
+	for i, s := range expectedSources {
+		if courseLib.Sources[i] != s {
+			t.Errorf("source[%d]: expected %q, got %q", i, s, courseLib.Sources[i])
+		}
+	}
+}
+
+func TestParseSConscriptCourseIncludes(t *testing.T) {
+	libs := ParseSConscript(courseSConscript)
+	var courseLib *Library
+	for i := range libs {
+		if libs[i].Name == "course.lib" {
+			courseLib = &libs[i]
+			break
+		}
+	}
+	if courseLib == nil {
+		t.Fatal("expected to find course.lib")
+	}
+
+	if len(courseLib.Includes) != 1 || courseLib.Includes[0] != "consts.inc" {
+		t.Errorf("expected includes [consts.inc], got %v", courseLib.Includes)
+	}
+}
+
+func TestGenerateModuleCourse(t *testing.T) {
+	libs := ParseSConscript(courseSConscript)
+	var courseLib *Library
+	for i := range libs {
+		if libs[i].Name == "course.lib" {
+			courseLib = &libs[i]
+			break
+		}
+	}
+	if courseLib == nil {
+		t.Fatal("expected to find course.lib")
+	}
+
+	output := GenerateModule(*courseLib, "COURSE.MODULE")
+
+	// Check include guard
+	if !strings.Contains(output, "#IF NOT (DEFINED (COURSE.MODULE))") {
+		t.Error("missing include guard #IF")
+	}
+	if !strings.Contains(output, "#DEFINE COURSE.MODULE") {
+		t.Error("missing include guard #DEFINE")
+	}
+	if !strings.Contains(output, "#ENDIF") {
+		t.Error("missing #ENDIF")
+	}
+
+	// Check consts.inc comes first (before source files)
+	constsIdx := strings.Index(output, `#INCLUDE "consts.inc"`)
+	utilsIdx := strings.Index(output, `#INCLUDE "utils.occ"`)
+	if constsIdx < 0 {
+		t.Error("missing consts.inc include")
+	}
+	if utilsIdx < 0 {
+		t.Error("missing utils.occ include")
+	}
+	if constsIdx > utilsIdx {
+		t.Error("consts.inc should come before utils.occ")
+	}
+
+	// Check all source files are included
+	for _, src := range courseLib.Sources {
+		if !strings.Contains(output, `#INCLUDE "`+src+`"`) {
+			t.Errorf("missing #INCLUDE for %s", src)
+		}
+	}
+}
+
+func TestParseSplitVars(t *testing.T) {
+	content := `my_srcs = Split('''
+    a.occ
+    b.occ
+    ''')`
+	vars := extractSplitVars(content)
+	if files, ok := vars["my_srcs"]; !ok {
+		t.Error("expected my_srcs variable")
+	} else if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(files))
+	}
+}
+
+func TestGenerateModuleOutput(t *testing.T) {
+	lib := Library{
+		Name:     "test.lib",
+		Sources:  []string{"a.occ", "b.occ"},
+		Includes: []string{"consts.inc"},
+	}
+	output := GenerateModule(lib, "TEST.MODULE")
+	expected := `#IF NOT (DEFINED (TEST.MODULE))
+#DEFINE TEST.MODULE
+#INCLUDE "consts.inc"
+#INCLUDE "a.occ"
+#INCLUDE "b.occ"
+#ENDIF
+`
+	if output != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, output)
+	}
+}

--- a/preproc/preproc.go
+++ b/preproc/preproc.go
@@ -1,0 +1,319 @@
+// Package preproc implements a textual preprocessor for occam source files.
+// It handles #IF/#ELSE/#ENDIF conditional compilation, #DEFINE symbols,
+// #INCLUDE file inclusion, and ignores #COMMENT/#PRAGMA/#USE directives.
+// The output is a single expanded string suitable for feeding into the lexer.
+package preproc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Option configures a Preprocessor.
+type Option func(*Preprocessor)
+
+// WithIncludePaths sets the search paths for #INCLUDE resolution.
+func WithIncludePaths(paths []string) Option {
+	return func(pp *Preprocessor) {
+		pp.includePaths = paths
+	}
+}
+
+// WithDefines sets predefined symbols.
+func WithDefines(defs map[string]string) Option {
+	return func(pp *Preprocessor) {
+		for k, v := range defs {
+			pp.defines[k] = v
+		}
+	}
+}
+
+// Preprocessor performs textual preprocessing of occam source.
+type Preprocessor struct {
+	defines      map[string]string
+	includePaths []string
+	errors       []string
+	processing   map[string]bool // absolute paths currently being processed (circular include detection)
+}
+
+// New creates a new Preprocessor with the given options.
+func New(opts ...Option) *Preprocessor {
+	pp := &Preprocessor{
+		defines:    map[string]string{},
+		processing: map[string]bool{},
+	}
+	// Predefined symbols
+	pp.defines["TARGET.BITS.PER.WORD"] = "64"
+
+	for _, opt := range opts {
+		opt(pp)
+	}
+	return pp
+}
+
+// Errors returns any errors accumulated during processing.
+func (pp *Preprocessor) Errors() []string {
+	return pp.errors
+}
+
+// ProcessFile reads and processes a file, resolving #INCLUDE directives.
+func (pp *Preprocessor) ProcessFile(filename string) (string, error) {
+	absPath, err := filepath.Abs(filename)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve path %q: %w", filename, err)
+	}
+
+	if pp.processing[absPath] {
+		return "", fmt.Errorf("circular include detected: %s", filename)
+	}
+	pp.processing[absPath] = true
+	defer delete(pp.processing, absPath)
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot read %q: %w", filename, err)
+	}
+
+	return pp.processSource(string(data), filepath.Dir(absPath))
+}
+
+// ProcessSource processes occam source text with no file context.
+// #INCLUDE directives will only resolve against includePaths.
+func (pp *Preprocessor) ProcessSource(source string) (string, error) {
+	return pp.processSource(source, "")
+}
+
+// processSource performs line-by-line preprocessing.
+// baseDir is the directory of the current file (for relative #INCLUDE resolution).
+func (pp *Preprocessor) processSource(source string, baseDir string) (string, error) {
+	lines := strings.Split(source, "\n")
+	var out strings.Builder
+	var condStack []condState
+
+	for i, line := range lines {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "#") {
+			directive, rest := parseDirectiveLine(trimmed)
+
+			switch directive {
+			case "DEFINE":
+				if isActive(condStack) {
+					sym := strings.TrimSpace(rest)
+					if sym != "" {
+						pp.defines[sym] = ""
+					}
+				}
+				out.WriteString("") // blank line preserves line numbers
+
+			case "IF":
+				val := pp.evalExpr(rest)
+				condStack = append(condStack, condState{active: val, seenTrue: val})
+				out.WriteString("")
+
+			case "ELSE":
+				if len(condStack) == 0 {
+					pp.errors = append(pp.errors, fmt.Sprintf("line %d: #ELSE without matching #IF", i+1))
+				} else {
+					top := &condStack[len(condStack)-1]
+					if top.seenTrue {
+						top.active = false
+					} else {
+						top.active = true
+						top.seenTrue = true
+					}
+				}
+				out.WriteString("")
+
+			case "ENDIF":
+				if len(condStack) == 0 {
+					pp.errors = append(pp.errors, fmt.Sprintf("line %d: #ENDIF without matching #IF", i+1))
+				} else {
+					condStack = condStack[:len(condStack)-1]
+				}
+				out.WriteString("")
+
+			case "INCLUDE":
+				if isActive(condStack) {
+					included, err := pp.resolveAndInclude(rest, baseDir)
+					if err != nil {
+						return "", fmt.Errorf("line %d: %w", i+1, err)
+					}
+					out.WriteString(included)
+				} else {
+					out.WriteString("")
+				}
+
+			case "COMMENT", "PRAGMA", "USE":
+				out.WriteString("") // no-op, blank line
+
+			default:
+				// Unknown directive — pass through if active
+				if isActive(condStack) {
+					out.WriteString(line)
+				} else {
+					out.WriteString("")
+				}
+			}
+		} else {
+			if isActive(condStack) {
+				out.WriteString(line)
+			} else {
+				out.WriteString("") // blank line preserves line numbers
+			}
+		}
+	}
+
+	if len(condStack) > 0 {
+		pp.errors = append(pp.errors, fmt.Sprintf("unterminated #IF (missing %d #ENDIF)", len(condStack)))
+	}
+
+	return out.String(), nil
+}
+
+// condState tracks one level of #IF/#ELSE nesting.
+type condState struct {
+	active   bool // currently emitting lines?
+	seenTrue bool // has any branch been true?
+}
+
+// isActive returns true if all condition stack levels are active.
+func isActive(stack []condState) bool {
+	for _, s := range stack {
+		if !s.active {
+			return false
+		}
+	}
+	return true
+}
+
+// parseDirectiveLine splits "#DIRECTIVE rest" into (directive, rest).
+func parseDirectiveLine(trimmed string) (string, string) {
+	// trimmed starts with "#"
+	s := trimmed[1:] // skip '#'
+	s = strings.TrimSpace(s)
+
+	idx := strings.IndexAny(s, " \t")
+	if idx == -1 {
+		return strings.ToUpper(s), ""
+	}
+	return strings.ToUpper(s[:idx]), strings.TrimSpace(s[idx+1:])
+}
+
+// resolveAndInclude resolves an #INCLUDE filename and processes the included file.
+func (pp *Preprocessor) resolveAndInclude(rest string, baseDir string) (string, error) {
+	filename := stripQuotes(rest)
+	if filename == "" {
+		return "", fmt.Errorf("#INCLUDE with empty filename")
+	}
+
+	// Try to find the file
+	resolved := pp.resolveIncludePath(filename, baseDir)
+	if resolved == "" {
+		return "", fmt.Errorf("cannot find included file %q", filename)
+	}
+
+	return pp.ProcessFile(resolved)
+}
+
+// resolveIncludePath searches for a file: first relative to baseDir, then in includePaths.
+func (pp *Preprocessor) resolveIncludePath(filename string, baseDir string) string {
+	// First: relative to current file's directory
+	if baseDir != "" {
+		candidate := filepath.Join(baseDir, filename)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+
+	// Then: each include path
+	for _, dir := range pp.includePaths {
+		candidate := filepath.Join(dir, filename)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+
+	return ""
+}
+
+// stripQuotes removes surrounding double quotes from a string.
+func stripQuotes(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// evalExpr evaluates a preprocessor conditional expression.
+// Supports: TRUE, FALSE, DEFINED (SYMBOL), NOT (expr), (SYMBOL = value)
+func (pp *Preprocessor) evalExpr(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return false
+	}
+
+	// TRUE / FALSE
+	if expr == "TRUE" {
+		return true
+	}
+	if expr == "FALSE" {
+		return false
+	}
+
+	// NOT (expr) or NOT DEFINED (...)
+	if strings.HasPrefix(expr, "NOT ") || strings.HasPrefix(expr, "NOT(") {
+		inner := strings.TrimPrefix(expr, "NOT")
+		inner = strings.TrimSpace(inner)
+		return !pp.evalExpr(inner)
+	}
+
+	// DEFINED (SYMBOL)
+	if strings.HasPrefix(expr, "DEFINED") {
+		inner := strings.TrimPrefix(expr, "DEFINED")
+		inner = strings.TrimSpace(inner)
+		sym := stripParens(inner)
+		_, ok := pp.defines[sym]
+		return ok
+	}
+
+	// Parenthesized expression
+	if strings.HasPrefix(expr, "(") && strings.HasSuffix(expr, ")") {
+		inner := expr[1 : len(expr)-1]
+		inner = strings.TrimSpace(inner)
+
+		// Check for equality: SYMBOL = value
+		if eqIdx := strings.Index(inner, "="); eqIdx >= 0 {
+			lhs := strings.TrimSpace(inner[:eqIdx])
+			rhs := strings.TrimSpace(inner[eqIdx+1:])
+			lhsVal, ok := pp.defines[lhs]
+			if !ok {
+				return false
+			}
+			return lhsVal == rhs
+		}
+
+		// Otherwise recurse
+		return pp.evalExpr(inner)
+	}
+
+	// Bare symbol — treat as DEFINED
+	_, ok := pp.defines[expr]
+	return ok
+}
+
+// stripParens removes surrounding parentheses and whitespace.
+func stripParens(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '(' && s[len(s)-1] == ')' {
+		return strings.TrimSpace(s[1 : len(s)-1])
+	}
+	return s
+}

--- a/preproc/preproc_test.go
+++ b/preproc/preproc_test.go
@@ -1,0 +1,437 @@
+package preproc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefineAndIfDefined(t *testing.T) {
+	pp := New()
+	src := `#DEFINE FOO
+#IF DEFINED (FOO)
+hello
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(out, "\n")
+	if strings.TrimSpace(lines[2]) != "hello" {
+		t.Errorf("expected 'hello' on line 3, got %q", lines[2])
+	}
+}
+
+func TestIfFalseExcludes(t *testing.T) {
+	pp := New()
+	src := `#IF FALSE
+visible
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "visible") {
+		t.Error("expected #IF FALSE to exclude content")
+	}
+}
+
+func TestIfTrue(t *testing.T) {
+	pp := New()
+	src := `#IF TRUE
+visible
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "visible") {
+		t.Error("expected #IF TRUE to include content")
+	}
+}
+
+func TestElse(t *testing.T) {
+	pp := New()
+	src := `#IF FALSE
+wrong
+#ELSE
+right
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "wrong") {
+		t.Error("should not contain 'wrong'")
+	}
+	if !strings.Contains(out, "right") {
+		t.Error("should contain 'right'")
+	}
+}
+
+func TestElseNotTakenWhenIfTrue(t *testing.T) {
+	pp := New()
+	src := `#IF TRUE
+right
+#ELSE
+wrong
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "right") {
+		t.Error("should contain 'right'")
+	}
+	if strings.Contains(out, "wrong") {
+		t.Error("should not contain 'wrong'")
+	}
+}
+
+func TestNestedIf(t *testing.T) {
+	pp := New()
+	src := `#DEFINE A
+#IF DEFINED (A)
+outer
+#IF FALSE
+inner-hidden
+#ENDIF
+outer2
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "outer") {
+		t.Error("should contain 'outer'")
+	}
+	if strings.Contains(out, "inner-hidden") {
+		t.Error("should not contain 'inner-hidden'")
+	}
+	if !strings.Contains(out, "outer2") {
+		t.Error("should contain 'outer2'")
+	}
+}
+
+func TestNotDefined(t *testing.T) {
+	pp := New()
+	src := `#IF NOT DEFINED (MISSING)
+visible
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "visible") {
+		t.Error("NOT DEFINED of missing symbol should be true")
+	}
+}
+
+func TestLineCountPreservation(t *testing.T) {
+	pp := New()
+	src := `line1
+#IF FALSE
+excluded
+#ENDIF
+line5
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(out, "\n")
+	// Original has 6 lines (including trailing empty from final \n)
+	srcLines := strings.Split(src, "\n")
+	if len(lines) != len(srcLines) {
+		t.Errorf("line count mismatch: got %d, want %d", len(lines), len(srcLines))
+	}
+	if lines[0] != "line1" {
+		t.Errorf("line 1: got %q, want %q", lines[0], "line1")
+	}
+	if lines[4] != "line5" {
+		t.Errorf("line 5: got %q, want %q", lines[4], "line5")
+	}
+}
+
+func TestCommentPragmaUseIgnored(t *testing.T) {
+	pp := New()
+	src := `#COMMENT "this is a comment"
+#PRAGMA SHARED
+#USE "somelib"
+hello
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Error("should contain 'hello'")
+	}
+	if strings.Contains(out, "COMMENT") || strings.Contains(out, "PRAGMA") || strings.Contains(out, "USE") {
+		t.Error("directives should be replaced with blank lines")
+	}
+}
+
+func TestEqualityExpression(t *testing.T) {
+	pp := New()
+	// TARGET.BITS.PER.WORD is predefined as "64"
+	src := `#IF (TARGET.BITS.PER.WORD = 64)
+is64
+#ENDIF
+#IF (TARGET.BITS.PER.WORD = 32)
+is32
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "is64") {
+		t.Error("should match 64-bit")
+	}
+	if strings.Contains(out, "is32") {
+		t.Error("should not match 32-bit")
+	}
+}
+
+func TestIncludeGuardPattern(t *testing.T) {
+	pp := New()
+	src := `#IF NOT (DEFINED (MY.MODULE))
+#DEFINE MY.MODULE
+content
+#ENDIF
+#IF NOT (DEFINED (MY.MODULE))
+#DEFINE MY.MODULE
+duplicate
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "content") {
+		t.Error("first include should have content")
+	}
+	if strings.Contains(out, "duplicate") {
+		t.Error("second include should be guarded")
+	}
+}
+
+func TestWithDefinesOption(t *testing.T) {
+	pp := New(WithDefines(map[string]string{"MY.FLAG": ""}))
+	src := `#IF DEFINED (MY.FLAG)
+flagged
+#ENDIF
+`
+	out, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "flagged") {
+		t.Error("pre-defined flag should be recognized")
+	}
+}
+
+func TestPredefinedTargetBits(t *testing.T) {
+	pp := New()
+	if _, ok := pp.defines["TARGET.BITS.PER.WORD"]; !ok {
+		t.Error("TARGET.BITS.PER.WORD should be predefined")
+	}
+}
+
+// --- File-based tests for #INCLUDE ---
+
+func TestIncludeFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create included file
+	incContent := "INT x:\nx := 42\n"
+	os.WriteFile(filepath.Join(tmpDir, "lib.inc"), []byte(incContent), 0644)
+
+	// Create main file
+	mainContent := `#INCLUDE "lib.inc"
+print.int(x)
+`
+	mainFile := filepath.Join(tmpDir, "main.occ")
+	os.WriteFile(mainFile, []byte(mainContent), 0644)
+
+	pp := New()
+	out, err := pp.ProcessFile(mainFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "INT x:") {
+		t.Error("should include content from lib.inc")
+	}
+	if !strings.Contains(out, "print.int(x)") {
+		t.Error("should contain main file content")
+	}
+}
+
+func TestIncludeWithSearchPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	libDir := filepath.Join(tmpDir, "libs")
+	os.Mkdir(libDir, 0755)
+
+	// Create included file in lib directory
+	os.WriteFile(filepath.Join(libDir, "helper.inc"), []byte("INT helper:\n"), 0644)
+
+	// Create main file that includes from a different directory
+	mainContent := `#INCLUDE "helper.inc"
+done
+`
+	mainFile := filepath.Join(tmpDir, "main.occ")
+	os.WriteFile(mainFile, []byte(mainContent), 0644)
+
+	pp := New(WithIncludePaths([]string{libDir}))
+	out, err := pp.ProcessFile(mainFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "INT helper:") {
+		t.Error("should find file via include path")
+	}
+}
+
+func TestIncludeGuardWithFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create guarded module file
+	modContent := `#IF NOT (DEFINED (MY.MODULE))
+#DEFINE MY.MODULE
+INT shared:
+#ENDIF
+`
+	os.WriteFile(filepath.Join(tmpDir, "my.module"), []byte(modContent), 0644)
+
+	// Create main file that includes twice
+	mainContent := `#INCLUDE "my.module"
+#INCLUDE "my.module"
+done
+`
+	mainFile := filepath.Join(tmpDir, "main.occ")
+	os.WriteFile(mainFile, []byte(mainContent), 0644)
+
+	pp := New()
+	out, err := pp.ProcessFile(mainFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "INT shared:" should appear only once
+	count := strings.Count(out, "INT shared:")
+	if count != 1 {
+		t.Errorf("expected 'INT shared:' once, found %d times", count)
+	}
+}
+
+func TestNestedIncludes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	os.WriteFile(filepath.Join(tmpDir, "inner.inc"), []byte("inner-content\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "outer.inc"), []byte("#INCLUDE \"inner.inc\"\nouter-content\n"), 0644)
+
+	mainContent := `#INCLUDE "outer.inc"
+main-content
+`
+	mainFile := filepath.Join(tmpDir, "main.occ")
+	os.WriteFile(mainFile, []byte(mainContent), 0644)
+
+	pp := New()
+	out, err := pp.ProcessFile(mainFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "inner-content") {
+		t.Error("should contain nested include content")
+	}
+	if !strings.Contains(out, "outer-content") {
+		t.Error("should contain outer include content")
+	}
+	if !strings.Contains(out, "main-content") {
+		t.Error("should contain main content")
+	}
+}
+
+func TestCircularIncludeError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	os.WriteFile(filepath.Join(tmpDir, "a.inc"), []byte("#INCLUDE \"b.inc\"\n"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "b.inc"), []byte("#INCLUDE \"a.inc\"\n"), 0644)
+
+	mainFile := filepath.Join(tmpDir, "a.inc")
+	pp := New()
+	_, err := pp.ProcessFile(mainFile)
+	if err == nil {
+		t.Error("expected circular include error")
+	}
+	if !strings.Contains(err.Error(), "circular") {
+		t.Errorf("expected 'circular' in error, got: %s", err)
+	}
+}
+
+func TestIncludeFileNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainContent := `#INCLUDE "nonexistent.inc"
+`
+	mainFile := filepath.Join(tmpDir, "main.occ")
+	os.WriteFile(mainFile, []byte(mainContent), 0644)
+
+	pp := New()
+	_, err := pp.ProcessFile(mainFile)
+	if err == nil {
+		t.Error("expected file not found error")
+	}
+	if !strings.Contains(err.Error(), "cannot find") {
+		t.Errorf("expected 'cannot find' in error, got: %s", err)
+	}
+}
+
+func TestUnterminatedIf(t *testing.T) {
+	pp := New()
+	src := `#IF TRUE
+hello
+`
+	_, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pp.Errors()) == 0 {
+		t.Error("expected unterminated #IF error")
+	}
+}
+
+func TestElseWithoutIf(t *testing.T) {
+	pp := New()
+	src := `#ELSE
+hello
+`
+	_, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pp.Errors()) == 0 {
+		t.Error("expected #ELSE without #IF error")
+	}
+}
+
+func TestEndifWithoutIf(t *testing.T) {
+	pp := New()
+	src := `#ENDIF
+`
+	_, err := pp.ProcessSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pp.Errors()) == 0 {
+		t.Error("expected #ENDIF without #IF error")
+	}
+}

--- a/scripts/clone-kroc.sh
+++ b/scripts/clone-kroc.sh
@@ -18,4 +18,14 @@ fi
 
 echo "Cloning KRoC repository into kroc/..."
 git clone "$REPO_URL" "$TARGET_DIR"
+
+# The KRoC repo contains .go files (in tests/ccsp-comparisons/go/) that fail
+# to compile. Adding a go.mod creates a module boundary so that "go build ./..."
+# and "go test ./..." from the project root skip the kroc/ directory entirely.
+cat > "$TARGET_DIR/go.mod" <<'EOF'
+module kroc-vendored
+
+go 1.25.6
+EOF
+
 echo "Done."


### PR DESCRIPTION
## Summary

- Add textual preprocessor (`preproc/`) handling `#IF`/`#ELSE`/`#ENDIF`/`#DEFINE`/`#INCLUDE` directives with search paths, include guards, and circular include detection
- Add module file generator (`modgen/`) that parses KRoC SConscript build files to produce `.module` files
- Wire into CLI with `-I` (include paths), `-D` (defines) flags and `gen-module` subcommand
- Add working example (`examples/include_demo.occ` + `examples/mathlib.module`)
- Update `clone-kroc.sh` to create `go.mod` boundary so `go build ./...` skips the kroc directory
- Comprehensive update to `TODO.md` with course.module feature gap analysis (16 features needed)

## Test plan

- [ ] `go test ./preproc` — 20 preprocessor unit tests (conditionals, nesting, file inclusion, include guards, circular detection)
- [ ] `go test ./modgen` — module generator tests against real course SConscript content
- [ ] `go test ./codegen` — existing tests pass + 3 new e2e tests (#INCLUDE, #IF FALSE, include guard)
- [ ] `go test ./...` — full suite passes with no regressions
- [ ] `go run . gen-module kroc/modules/course/libsrc/SConscript` generates correct course.module
- [ ] `go run . -I examples -o /tmp/demo.go examples/include_demo.occ && go run /tmp/demo.go` outputs 42, 20, 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)