### PR TITLE
Add abbreviation support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,8 @@ Six packages, one pipeline:
 | `PROC f(CHAN OF INT c?)` | `func f(c <-chan int)` (input/receive-only) |
 | `PROC f(CHAN OF INT c!)` | `func f(c chan<- int)` (output/send-only) |
 | Non-VAL params | `*type` pointer params, callers pass `&arg` |
+| `VAL INT x IS 42:` | `x := 42` (abbreviation/named constant) |
+| `INT y IS z:` | `y := z` (non-VAL abbreviation) |
 | `#INCLUDE "file"` | Textual inclusion (preprocessor, pre-lexer) |
 | `#IF`/`#ELSE`/`#ENDIF` | Conditional compilation (preprocessor) |
 | `#DEFINE SYMBOL` | Define preprocessor symbol |
@@ -138,8 +140,8 @@ Typical workflow for a new language construct:
 
 ## What's Implemented
 
-Preprocessor (`#IF`/`#ELSE`/`#ENDIF`/`#DEFINE`/`#INCLUDE` with search paths, include guards, `#COMMENT`/`#PRAGMA`/`#USE` ignored), module file generation from SConscript (`gen-module` subcommand), SEQ, PAR, IF, WHILE, CASE, ALT (with guards and timer timeouts), SKIP, STOP, variable/array/channel/timer declarations, assignments (simple and indexed), channel send/receive, channel arrays (`[n]CHAN OF TYPE` with indexed send/receive and `[]CHAN OF TYPE` proc params), PROC (with VAL, reference, CHAN, and []CHAN params), channel direction restrictions (`CHAN OF INT c?` → `<-chan int`, `CHAN OF INT c!` → `chan<- int`), FUNCTION (IS and VALOF forms), replicators on SEQ and PAR, arithmetic/comparison/logical/AFTER/bitwise operators, type conversions (`INT expr`, `BYTE expr`, `REAL32 expr`, `REAL64 expr`, etc.), REAL32/REAL64 types, string literals, built-in print procedures, protocols (simple, sequential, and variant), record types (with field access via bracket syntax), SIZE operator.
+Preprocessor (`#IF`/`#ELSE`/`#ENDIF`/`#DEFINE`/`#INCLUDE` with search paths, include guards, `#COMMENT`/`#PRAGMA`/`#USE` ignored), module file generation from SConscript (`gen-module` subcommand), SEQ, PAR, IF, WHILE, CASE, ALT (with guards and timer timeouts), SKIP, STOP, variable/array/channel/timer declarations, abbreviations (`VAL INT x IS 42:`, `INT y IS z:`), assignments (simple and indexed), channel send/receive, channel arrays (`[n]CHAN OF TYPE` with indexed send/receive and `[]CHAN OF TYPE` proc params), PROC (with VAL, reference, CHAN, and []CHAN params), channel direction restrictions (`CHAN OF INT c?` → `<-chan int`, `CHAN OF INT c!` → `chan<- int`), FUNCTION (IS and VALOF forms), replicators on SEQ and PAR, arithmetic/comparison/logical/AFTER/bitwise operators, type conversions (`INT expr`, `BYTE expr`, `REAL32 expr`, `REAL64 expr`, etc.), REAL32/REAL64 types, string literals, built-in print procedures, protocols (simple, sequential, and variant), record types (with field access via bracket syntax), SIZE operator.
 
 ## Not Yet Implemented
 
-Abbreviations (`name IS expr:`), PRI ALT/PRI PAR, PLACED PAR, PORT OF. See `TODO.md` for the full list with priorities.
+PRI ALT/PRI PAR, PLACED PAR, PORT OF. See `TODO.md` for the full list with priorities.

--- a/TODO.md
+++ b/TODO.md
@@ -67,7 +67,7 @@ These features are needed to transpile the KRoC course module (`kroc/modules/cou
 
 | Feature | Notes | Used in |
 |---------|-------|---------|
-| **Abbreviations** | `VAL INT x IS 1:`, `VAL BYTE ch IS 'A':` — named constants. The most pervasive missing feature. | consts.inc, all .occ files |
+| ~~**Abbreviations**~~ | ~~`VAL INT x IS 1:`, `VAL BYTE ch IS 'A':` — named constants.~~ **DONE** | consts.inc, all .occ files |
 | **`CHAN BYTE` shorthand** | `CHAN BYTE out!` without `OF`. KRoC allows omitting `OF` for channel types. | all .occ files |
 | **Open array params** | `VAL []BYTE s`, `[]BYTE s` — unsized array/slice parameters for PROCs and FUNCTIONs. (`[]CHAN OF T` is already supported.) | utils.occ, string.occ, file_in.occ, stringbuf.occ |
 | **BYTE literals** | `'A'`, `'0'`, `' '` — single-quoted character literals. | utils.occ, file_in.occ, string.occ |

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -427,3 +427,15 @@ type RecordField struct {
 
 func (rd *RecordDecl) statementNode()       {}
 func (rd *RecordDecl) TokenLiteral() string { return rd.Token.Literal }
+
+// Abbreviation represents an abbreviation: VAL INT x IS 42: or INT y IS z:
+type Abbreviation struct {
+	Token lexer.Token // VAL or type token
+	IsVal bool        // true for VAL abbreviations
+	Type  string      // "INT", "BYTE", "BOOL", etc.
+	Name  string      // variable name
+	Value Expression  // the expression
+}
+
+func (a *Abbreviation) statementNode()       {}
+func (a *Abbreviation) TokenLiteral() string { return a.Token.Literal }

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -445,12 +445,21 @@ func (g *Generator) generateStatement(stmt ast.Statement) {
 		g.generateVariantReceive(s)
 	case *ast.RecordDecl:
 		g.generateRecordDecl(s)
+	case *ast.Abbreviation:
+		g.generateAbbreviation(s)
 	}
 }
 
 func (g *Generator) generateVarDecl(decl *ast.VarDecl) {
 	goType := g.occamTypeToGo(decl.Type)
 	g.writeLine(fmt.Sprintf("var %s %s", strings.Join(decl.Names, ", "), goType))
+}
+
+func (g *Generator) generateAbbreviation(abbr *ast.Abbreviation) {
+	g.builder.WriteString(strings.Repeat("\t", g.indent))
+	g.write(fmt.Sprintf("%s := ", abbr.Name))
+	g.generateExpression(abbr.Value)
+	g.write("\n")
 }
 
 func (g *Generator) generateChanDecl(decl *ast.ChanDecl) {

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -463,3 +463,21 @@ func TestSizeOperator(t *testing.T) {
 		}
 	}
 }
+
+func TestAbbreviation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"VAL INT x IS 42:\n", "x := 42"},
+		{"VAL BOOL flag IS TRUE:\n", "flag := true"},
+		{"INT y IS z:\n", "y := z"},
+	}
+
+	for _, tt := range tests {
+		output := transpile(t, tt.input)
+		if !strings.Contains(output, tt.expected) {
+			t.Errorf("for input %q: expected %q in output, got:\n%s", tt.input, tt.expected, output)
+		}
+	}
+}

--- a/codegen/e2e_test.go
+++ b/codegen/e2e_test.go
@@ -1439,3 +1439,43 @@ func TestE2E_SizeString(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, output)
 	}
 }
+
+func TestE2E_ValAbbreviation(t *testing.T) {
+	occam := `SEQ
+  VAL INT x IS 42:
+  print.int(x)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "42\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_AbbreviationWithExpression(t *testing.T) {
+	occam := `SEQ
+  INT a:
+  a := 10
+  VAL INT b IS (a + 5):
+  print.int(b)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "15\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_NonValAbbreviation(t *testing.T) {
+	occam := `SEQ
+  INT x:
+  x := 7
+  INT y IS x:
+  print.int(y)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "7\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}


### PR DESCRIPTION
## Summary
- Add occam abbreviation support (`VAL INT x IS 42:`, `INT y IS z:`)
- New `Abbreviation` AST node, parser handling for both VAL and non-VAL forms
- Codegen emits `:=` assignments for all abbreviations

## Test plan
- [x] 4 parser unit tests (VAL, non-VAL, BOOL, expression forms)
- [x] 3 codegen unit tests
- [x] 3 e2e tests (transpile → compile → run)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)