### PR TITLE
Add CHAN BYTE shorthand support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -68,7 +68,7 @@ These features are needed to transpile the KRoC course module (`kroc/modules/cou
 | Feature | Notes | Used in |
 |---------|-------|---------|
 | ~~**Abbreviations**~~ | ~~`VAL INT x IS 1:`, `VAL BYTE ch IS 'A':` — named constants.~~ **DONE** | consts.inc, all .occ files |
-| **`CHAN BYTE` shorthand** | `CHAN BYTE out!` without `OF`. KRoC allows omitting `OF` for channel types. | all .occ files |
+| ~~**`CHAN BYTE` shorthand**~~ | ~~`CHAN BYTE out!` without `OF`. KRoC allows omitting `OF` for channel types.~~ **DONE** | all .occ files |
 | ~~**Open array params**~~ | ~~`VAL []BYTE s`, `[]BYTE s` — unsized array/slice parameters for PROCs and FUNCTIONs. (`[]CHAN OF T` is already supported.)~~ **DONE** | utils.occ, string.occ, file_in.occ, stringbuf.occ |
 | **BYTE literals** | `'A'`, `'0'`, `' '` — single-quoted character literals. | utils.occ, file_in.occ, string.occ |
 | **Occam escape sequences** | `*n` (newline), `*c` (carriage return), `*t` (tab) — occam uses `*` not `\` for escapes in strings and byte literals. | utils.occ, file_in.occ |

--- a/codegen/e2e_test.go
+++ b/codegen/e2e_test.go
@@ -1498,3 +1498,19 @@ func TestE2E_NonValAbbreviation(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, output)
 	}
 }
+
+func TestE2EChanShorthand(t *testing.T) {
+	occam := `SEQ
+  CHAN INT c:
+  INT result:
+  PAR
+    c ! 42
+    c ? result
+  print.int(result)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "42\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}


### PR DESCRIPTION
## Summary
- Allow omitting `OF` in channel type declarations (`CHAN BYTE` as shorthand for `CHAN OF BYTE`)
- Supported in all contexts: channel declarations, channel arrays, and proc parameters
- Mark feature as done in TODO.md

## Test plan
- [x] Parser unit tests for `CHAN BYTE c:`, `[5]CHAN INT cs:`, and proc params `CHAN BYTE input?` / `[]CHAN INT cs`
- [x] E2E test: transpile → compile → run with `CHAN INT` shorthand
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)