### PR TITLE
Add replicated IF support (IF i = 0 FOR n)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,7 +75,7 @@ These features are needed to transpile the KRoC course module (`kroc/modules/cou
 | **PROC terminator `:` ** | Standalone `:` at the end of a PROC/FUNCTION body (KRoC style). | all .occ files |
 | **Nested PROCs/FUNCTIONs** | Local PROC/FUNCTION definitions inside a PROC body. | float_io.occ, stringbuf.occ |
 | **Multi-result FUNCTIONs** | `INT, INT FUNCTION f(...)` returning multiple values via `RESULT a, b`. | random.occ, utils.occ, string.occ, float_io.occ |
-| **Replicated IF** | `IF i = 0 FOR n` — replicated conditional. | utils.occ, file_in.occ, string.occ, float_io.occ |
+| ~~**Replicated IF**~~ | ~~`IF i = 0 FOR n` — replicated conditional.~~ **DONE** | utils.occ, file_in.occ, string.occ, float_io.occ |
 | **Hex integer literals** | `#FF`, `#80000000` — prefixed with `#`. | float_io.occ, stringbuf.occ |
 | **Checked arithmetic** | `TIMES`, `PLUS`, `MINUS` — modular (wrapping) arithmetic operators. | demo_cycles.occ, random.occ, utils.occ |
 | **`MOSTNEG INT`** | Most-negative integer constant. | utils.occ |

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -178,8 +178,9 @@ func (w *WhileLoop) TokenLiteral() string { return w.Token.Literal }
 
 // IfStatement represents an IF statement
 type IfStatement struct {
-	Token   lexer.Token // the IF token
-	Choices []IfChoice
+	Token      lexer.Token // the IF token
+	Choices    []IfChoice
+	Replicator *Replicator // optional replicator for IF i = start FOR count
 }
 
 type IfChoice struct {

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -163,6 +163,24 @@ func TestIfStatement(t *testing.T) {
 	}
 }
 
+func TestReplicatedIf(t *testing.T) {
+	input := `IF i = 0 FOR 5
+  i = 3
+    SKIP
+`
+	output := transpile(t, input)
+
+	if !strings.Contains(output, "for i := 0; i < 0 + 5; i++") {
+		t.Errorf("expected for loop in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "if (i == 3)") {
+		t.Errorf("expected 'if (i == 3)' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "break") {
+		t.Errorf("expected 'break' in output, got:\n%s", output)
+	}
+}
+
 func TestArrayDecl(t *testing.T) {
 	input := `[5]INT arr:
 `

--- a/codegen/e2e_test.go
+++ b/codegen/e2e_test.go
@@ -550,6 +550,29 @@ func TestE2E_ReplicatedPar(t *testing.T) {
 	}
 }
 
+func TestE2E_ReplicatedIf(t *testing.T) {
+	// Test replicated IF: find first matching element
+	occam := `SEQ
+  INT result:
+  result := -1
+  [5]INT arr:
+  arr[0] := 10
+  arr[1] := 20
+  arr[2] := 30
+  arr[3] := 40
+  arr[4] := 50
+  IF i = 0 FOR 5
+    arr[i] = 30
+      result := i
+  print.int(result)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "2\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
 func TestE2E_ArrayBasic(t *testing.T) {
 	// Test basic array: declare, store, load
 	occam := `SEQ

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1944,6 +1944,17 @@ func (p *Parser) parseWhileLoop() *ast.WhileLoop {
 func (p *Parser) parseIfStatement() *ast.IfStatement {
 	stmt := &ast.IfStatement{Token: p.curToken}
 
+	// Check for replicator: IF i = start FOR count
+	if p.peekTokenIs(lexer.IDENT) {
+		p.nextToken() // move to identifier
+		if p.peekTokenIs(lexer.EQ) {
+			stmt.Replicator = p.parseReplicator()
+		} else {
+			p.addError("unexpected identifier after IF")
+			return stmt
+		}
+	}
+
 	// Skip to next line
 	for p.peekTokenIs(lexer.NEWLINE) {
 		p.nextToken()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -488,6 +488,46 @@ func TestReplicatedPar(t *testing.T) {
 	}
 }
 
+func TestReplicatedIf(t *testing.T) {
+	input := `IF i = 0 FOR 5
+  i = 3
+    SKIP
+`
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(program.Statements))
+	}
+
+	ifStmt, ok := program.Statements[0].(*ast.IfStatement)
+	if !ok {
+		t.Fatalf("expected IfStatement, got %T", program.Statements[0])
+	}
+
+	if ifStmt.Replicator == nil {
+		t.Fatal("expected replicator on IF statement")
+	}
+
+	if ifStmt.Replicator.Variable != "i" {
+		t.Errorf("expected variable 'i', got %s", ifStmt.Replicator.Variable)
+	}
+
+	if len(ifStmt.Choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(ifStmt.Choices))
+	}
+
+	if ifStmt.Choices[0].Condition == nil {
+		t.Error("expected condition on choice")
+	}
+
+	if ifStmt.Choices[0].Body == nil {
+		t.Error("expected body on choice")
+	}
+}
+
 func TestArrayDecl(t *testing.T) {
 	input := `[5]INT arr:
 `


### PR DESCRIPTION
## Summary
- Add replicated IF construct (`IF i = 0 FOR n`) which iterates through replicator values and executes the body of the first matching condition
- Generates a `for` loop wrapping the if/else-if chain with `break` on first match
- Follows the same replicator pattern used by replicated SEQ and PAR

## Test plan
- [x] Parser unit test: verifies replicator fields are parsed correctly
- [x] Codegen unit test: verifies output contains for loop, condition, and break
- [x] E2E test: searches an array for a value using replicated IF, verifies correct index found
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)