### PR TITLE
Add hex integer literal support (#FF syntax)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ Six packages, one pipeline:
 | `#IF`/`#ELSE`/`#ENDIF` | Conditional compilation (preprocessor) |
 | `#DEFINE SYMBOL` | Define preprocessor symbol |
 | `#COMMENT`/`#PRAGMA`/`#USE` | Ignored (blank line) |
+| `#FF`, `#80000000` | `0xFF`, `0x80000000` (hex integer literals) |
 | `SIZE arr` / `SIZE "str"` | `len(arr)` / `len("str")` |
 
 ## Key Parser Patterns
@@ -142,7 +143,7 @@ Typical workflow for a new language construct:
 
 ## What's Implemented
 
-Preprocessor (`#IF`/`#ELSE`/`#ENDIF`/`#DEFINE`/`#INCLUDE` with search paths, include guards, `#COMMENT`/`#PRAGMA`/`#USE` ignored), module file generation from SConscript (`gen-module` subcommand), SEQ, PAR, IF, WHILE, CASE, ALT (with guards and timer timeouts), SKIP, STOP, variable/array/channel/timer declarations, abbreviations (`VAL INT x IS 42:`, `INT y IS z:`), assignments (simple and indexed), channel send/receive, channel arrays (`[n]CHAN OF TYPE` with indexed send/receive and `[]CHAN OF TYPE` proc params), PROC (with VAL, reference, CHAN, []CHAN, and open array `[]TYPE` params), channel direction restrictions (`CHAN OF INT c?` → `<-chan int`, `CHAN OF INT c!` → `chan<- int`), FUNCTION (IS and VALOF forms), KRoC-style colon terminators on PROC/FUNCTION (optional), replicators on SEQ and PAR, arithmetic/comparison/logical/AFTER/bitwise operators, type conversions (`INT expr`, `BYTE expr`, `REAL32 expr`, `REAL64 expr`, etc.), REAL32/REAL64 types, string literals, byte literals (`'A'`, `'*n'` with occam escape sequences), built-in print procedures, protocols (simple, sequential, and variant), record types (with field access via bracket syntax), SIZE operator.
+Preprocessor (`#IF`/`#ELSE`/`#ENDIF`/`#DEFINE`/`#INCLUDE` with search paths, include guards, `#COMMENT`/`#PRAGMA`/`#USE` ignored), module file generation from SConscript (`gen-module` subcommand), SEQ, PAR, IF, WHILE, CASE, ALT (with guards and timer timeouts), SKIP, STOP, variable/array/channel/timer declarations, abbreviations (`VAL INT x IS 42:`, `INT y IS z:`), assignments (simple and indexed), channel send/receive, channel arrays (`[n]CHAN OF TYPE` with indexed send/receive and `[]CHAN OF TYPE` proc params), PROC (with VAL, reference, CHAN, []CHAN, and open array `[]TYPE` params), channel direction restrictions (`CHAN OF INT c?` → `<-chan int`, `CHAN OF INT c!` → `chan<- int`), FUNCTION (IS and VALOF forms), KRoC-style colon terminators on PROC/FUNCTION (optional), replicators on SEQ and PAR, arithmetic/comparison/logical/AFTER/bitwise operators, type conversions (`INT expr`, `BYTE expr`, `REAL32 expr`, `REAL64 expr`, etc.), REAL32/REAL64 types, hex integer literals (`#FF`, `#80000000`), string literals, byte literals (`'A'`, `'*n'` with occam escape sequences), built-in print procedures, protocols (simple, sequential, and variant), record types (with field access via bracket syntax), SIZE operator.
 
 ## Not Yet Implemented
 

--- a/TODO.md
+++ b/TODO.md
@@ -76,7 +76,7 @@ These features are needed to transpile the KRoC course module (`kroc/modules/cou
 | **Nested PROCs/FUNCTIONs** | Local PROC/FUNCTION definitions inside a PROC body. | float_io.occ, stringbuf.occ |
 | **Multi-result FUNCTIONs** | `INT, INT FUNCTION f(...)` returning multiple values via `RESULT a, b`. | random.occ, utils.occ, string.occ, float_io.occ |
 | ~~**Replicated IF**~~ | ~~`IF i = 0 FOR n` — replicated conditional.~~ **DONE** | utils.occ, file_in.occ, string.occ, float_io.occ |
-| **Hex integer literals** | `#FF`, `#80000000` — prefixed with `#`. | float_io.occ, stringbuf.occ |
+| ~~**Hex integer literals**~~ | ~~`#FF`, `#80000000` — prefixed with `#`.~~ **DONE** | float_io.occ, stringbuf.occ |
 | **Checked arithmetic** | `TIMES`, `PLUS`, `MINUS` — modular (wrapping) arithmetic operators. | demo_cycles.occ, random.occ, utils.occ |
 | **`MOSTNEG INT`** | Most-negative integer constant. | utils.occ |
 | **`INITIAL` declarations** | `INITIAL INT i IS 0:` — mutable variable with initial value. | stringbuf.occ |

--- a/codegen/e2e_types_test.go
+++ b/codegen/e2e_types_test.go
@@ -105,6 +105,32 @@ func TestE2E_Real32Array(t *testing.T) {
 	}
 }
 
+func TestE2E_HexLiteral(t *testing.T) {
+	occam := `SEQ
+  INT x:
+  x := #FF
+  print.int(x)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "255\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_HexLiteralInExpression(t *testing.T) {
+	occam := `SEQ
+  INT x:
+  x := #0A + #14
+  print.int(x)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "30\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
 func TestE2E_BitwiseAnd(t *testing.T) {
 	occam := `SEQ
   INT x:

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -168,6 +168,15 @@ func (l *Lexer) NextToken() Token {
 		} else {
 			tok = l.newToken(GT, l.ch)
 		}
+	case '#':
+		if isHexDigit(l.peekChar()) {
+			tok.Type = INT
+			tok.Literal = l.readHexNumber()
+			tok.Line = l.line
+			return tok
+		} else {
+			tok = l.newToken(ILLEGAL, l.ch)
+		}
 	case '-':
 		if l.peekChar() == '-' {
 			l.skipComment()
@@ -246,6 +255,16 @@ func (l *Lexer) readNumber() string {
 		l.readChar()
 	}
 	return l.input[position:l.position]
+}
+
+func (l *Lexer) readHexNumber() string {
+	// Current char is '#', skip it
+	l.readChar()
+	position := l.position
+	for isHexDigit(l.ch) {
+		l.readChar()
+	}
+	return "0x" + l.input[position:l.position]
 }
 
 func (l *Lexer) readString() string {
@@ -353,6 +372,10 @@ func isLetter(ch byte) bool {
 
 func isDigit(ch byte) bool {
 	return ch >= '0' && ch <= '9'
+}
+
+func isHexDigit(ch byte) bool {
+	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
 }
 
 // Tokenize returns all tokens from the input

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -221,6 +221,55 @@ func TestBitwiseVsArithmetic(t *testing.T) {
 	}
 }
 
+func TestHexLiterals(t *testing.T) {
+	input := "x := #FF\n"
+	tests := []struct {
+		expectedType    TokenType
+		expectedLiteral string
+	}{
+		{IDENT, "x"},
+		{ASSIGN, ":="},
+		{INT, "0xFF"},
+		{NEWLINE, "\\n"},
+		{EOF, ""},
+	}
+
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q (literal=%q)",
+				i, tt.expectedType, tok.Type, tok.Literal)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q",
+				i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+
+	// Test lowercase hex digits
+	input2 := "#1a2b\n"
+	l2 := New(input2)
+	tok := l2.NextToken()
+	if tok.Type != INT {
+		t.Fatalf("hex lowercase - type wrong. expected=%q, got=%q", INT, tok.Type)
+	}
+	if tok.Literal != "0x1a2b" {
+		t.Fatalf("hex lowercase - literal wrong. expected=%q, got=%q", "0x1a2b", tok.Literal)
+	}
+
+	// Test #0
+	input3 := "#0\n"
+	l3 := New(input3)
+	tok3 := l3.NextToken()
+	if tok3.Type != INT {
+		t.Fatalf("hex zero - type wrong. expected=%q, got=%q", INT, tok3.Type)
+	}
+	if tok3.Literal != "0x0" {
+		t.Fatalf("hex zero - literal wrong. expected=%q, got=%q", "0x0", tok3.Literal)
+	}
+}
+
 func TestNestedIndentation(t *testing.T) {
 	input := `SEQ
   INT x:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/codeassociates/occam2go/ast"
 	"github.com/codeassociates/occam2go/lexer"
@@ -2141,7 +2142,13 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 			left = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 		}
 	case lexer.INT:
-		val, err := strconv.ParseInt(p.curToken.Literal, 10, 64)
+		base := 10
+		literal := p.curToken.Literal
+		if strings.HasPrefix(literal, "0x") || strings.HasPrefix(literal, "0X") {
+			base = 16
+			literal = literal[2:]
+		}
+		val, err := strconv.ParseInt(literal, base, 64)
 		if err != nil {
 			p.addError(fmt.Sprintf("could not parse %q as integer", p.curToken.Literal))
 			return nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2184,3 +2184,57 @@ func TestChanParamShorthand(t *testing.T) {
 		t.Errorf("param 1: expected ChanElemType=INT, got %s", p1.ChanElemType)
 	}
 }
+
+func TestHexIntegerLiteral(t *testing.T) {
+	input := `x := #FF
+`
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(program.Statements))
+	}
+
+	assign, ok := program.Statements[0].(*ast.Assignment)
+	if !ok {
+		t.Fatalf("expected Assignment, got %T", program.Statements[0])
+	}
+
+	intLit, ok := assign.Value.(*ast.IntegerLiteral)
+	if !ok {
+		t.Fatalf("expected IntegerLiteral, got %T", assign.Value)
+	}
+
+	if intLit.Value != 255 {
+		t.Errorf("expected value 255, got %d", intLit.Value)
+	}
+}
+
+func TestHexIntegerLiteralLarge(t *testing.T) {
+	input := `x := #80000000
+`
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(program.Statements))
+	}
+
+	assign, ok := program.Statements[0].(*ast.Assignment)
+	if !ok {
+		t.Fatalf("expected Assignment, got %T", program.Statements[0])
+	}
+
+	intLit, ok := assign.Value.(*ast.IntegerLiteral)
+	if !ok {
+		t.Fatalf("expected IntegerLiteral, got %T", assign.Value)
+	}
+
+	if intLit.Value != 0x80000000 {
+		t.Errorf("expected value %d, got %d", int64(0x80000000), intLit.Value)
+	}
+}


### PR DESCRIPTION
## Summary
- Lex occam hex literals (`#FF`, `#80000000`, `#0`) as `INT` tokens with `0x`-prefixed literals
- Parse hex-prefixed token literals using base-16 `strconv.ParseInt`
- Add lexer, parser, and end-to-end tests for hex integer literals
- Update TODO.md and CLAUDE.md to reflect the new feature

## Test plan
- [x] `TestHexLiterals` — lexer correctly tokenizes `#FF`, `#1a2b`, `#0`
- [x] `TestHexIntegerLiteral` — parser converts `#FF` to value 255
- [x] `TestHexIntegerLiteralLarge` — parser converts `#80000000` to correct value
- [x] `TestE2E_HexLiteral` — full pipeline: `#FF` prints `255`
- [x] `TestE2E_HexLiteralInExpression` — hex arithmetic: `#0A + #14` prints `30`
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)