### PR TITLE
Add multi-result FUNCTION support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,9 @@ Six packages, one pipeline:
 | `c ? x` | `x = <-c` |
 | `PROC name(...)` | `func name(...)` |
 | `INT FUNCTION name(...) IS expr` | `func name(...) int { return expr }` |
+| `INT, INT FUNCTION name(...)` | `func name(...) (int, int) { ... }` |
+| `RESULT expr1, expr2` | `return expr1, expr2` |
+| `a, b := func(...)` | `a, b = func(...)` (multi-assignment) |
 | `TIMER` / `tim ? t` | `time.Now().UnixMicro()` |
 | `=` / `<>` | `==` / `!=` |
 | `AND` / `OR` / `NOT` | `&&` / `||` / `!` |
@@ -143,7 +146,7 @@ Typical workflow for a new language construct:
 
 ## What's Implemented
 
-Preprocessor (`#IF`/`#ELSE`/`#ENDIF`/`#DEFINE`/`#INCLUDE` with search paths, include guards, `#COMMENT`/`#PRAGMA`/`#USE` ignored), module file generation from SConscript (`gen-module` subcommand), SEQ, PAR, IF, WHILE, CASE, ALT (with guards and timer timeouts), SKIP, STOP, variable/array/channel/timer declarations, abbreviations (`VAL INT x IS 42:`, `INT y IS z:`), assignments (simple and indexed), channel send/receive, channel arrays (`[n]CHAN OF TYPE` with indexed send/receive and `[]CHAN OF TYPE` proc params), PROC (with VAL, reference, CHAN, []CHAN, and open array `[]TYPE` params), channel direction restrictions (`CHAN OF INT c?` → `<-chan int`, `CHAN OF INT c!` → `chan<- int`), FUNCTION (IS and VALOF forms), KRoC-style colon terminators on PROC/FUNCTION (optional), replicators on SEQ and PAR, arithmetic/comparison/logical/AFTER/bitwise operators, type conversions (`INT expr`, `BYTE expr`, `REAL32 expr`, `REAL64 expr`, etc.), REAL32/REAL64 types, hex integer literals (`#FF`, `#80000000`), string literals, byte literals (`'A'`, `'*n'` with occam escape sequences), built-in print procedures, protocols (simple, sequential, and variant), record types (with field access via bracket syntax), SIZE operator.
+Preprocessor (`#IF`/`#ELSE`/`#ENDIF`/`#DEFINE`/`#INCLUDE` with search paths, include guards, `#COMMENT`/`#PRAGMA`/`#USE` ignored), module file generation from SConscript (`gen-module` subcommand), SEQ, PAR, IF, WHILE, CASE, ALT (with guards and timer timeouts), SKIP, STOP, variable/array/channel/timer declarations, abbreviations (`VAL INT x IS 42:`, `INT y IS z:`), assignments (simple and indexed), channel send/receive, channel arrays (`[n]CHAN OF TYPE` with indexed send/receive and `[]CHAN OF TYPE` proc params), PROC (with VAL, reference, CHAN, []CHAN, and open array `[]TYPE` params), channel direction restrictions (`CHAN OF INT c?` → `<-chan int`, `CHAN OF INT c!` → `chan<- int`), FUNCTION (IS and VALOF forms, including multi-result `INT, INT FUNCTION` with `RESULT a, b`), multi-assignment (`a, b := func(...)`), KRoC-style colon terminators on PROC/FUNCTION (optional), replicators on SEQ and PAR, arithmetic/comparison/logical/AFTER/bitwise operators, type conversions (`INT expr`, `BYTE expr`, `REAL32 expr`, `REAL64 expr`, etc.), REAL32/REAL64 types, hex integer literals (`#FF`, `#80000000`), string literals, byte literals (`'A'`, `'*n'` with occam escape sequences), built-in print procedures, protocols (simple, sequential, and variant), record types (with field access via bracket syntax), SIZE operator.
 
 ## Not Yet Implemented
 

--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,7 @@ These features are needed to transpile the KRoC course module (`kroc/modules/cou
 | ~~**Occam escape sequences**~~ | ~~`*n` (newline), `*c` (carriage return), `*t` (tab) — occam uses `*` not `\` for escapes in strings and byte literals.~~ **DONE** | utils.occ, file_in.occ |
 | ~~**PROC terminator `:`**~~ | ~~Standalone `:` at the end of a PROC/FUNCTION body (KRoC style).~~ **DONE** | all .occ files |
 | **Nested PROCs/FUNCTIONs** | Local PROC/FUNCTION definitions inside a PROC body. | float_io.occ, stringbuf.occ |
-| **Multi-result FUNCTIONs** | `INT, INT FUNCTION f(...)` returning multiple values via `RESULT a, b`. | random.occ, utils.occ, string.occ, float_io.occ |
+| ~~**Multi-result FUNCTIONs**~~ | ~~`INT, INT FUNCTION f(...)` returning multiple values via `RESULT a, b`.~~ **DONE** | random.occ, utils.occ, string.occ, float_io.occ |
 | ~~**Replicated IF**~~ | ~~`IF i = 0 FOR n` — replicated conditional.~~ **DONE** | utils.occ, file_in.occ, string.occ, float_io.occ |
 | ~~**Hex integer literals**~~ | ~~`#FF`, `#80000000` — prefixed with `#`.~~ **DONE** | float_io.occ, stringbuf.occ |
 | **Checked arithmetic** | `TIMES`, `PLUS`, `MINUS` — modular (wrapping) arithmetic operators. | demo_cycles.occ, random.occ, utils.occ |

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -65,6 +65,16 @@ type Assignment struct {
 func (a *Assignment) statementNode()       {}
 func (a *Assignment) TokenLiteral() string { return a.Token.Literal }
 
+// MultiAssignment represents a multi-target assignment: a, b := func(x)
+type MultiAssignment struct {
+	Token   lexer.Token  // the := token
+	Targets []string     // variable names on the left side
+	Values  []Expression // expressions on the right side
+}
+
+func (m *MultiAssignment) statementNode()       {}
+func (m *MultiAssignment) TokenLiteral() string { return m.Token.Literal }
+
 // SeqBlock represents a SEQ block (sequential execution)
 // If Replicator is non-nil, this is a replicated SEQ (SEQ i = 0 FOR n)
 type SeqBlock struct {
@@ -143,14 +153,14 @@ type ProcCall struct {
 func (p *ProcCall) statementNode()       {}
 func (p *ProcCall) TokenLiteral() string { return p.Token.Literal }
 
-// FuncDecl represents a function declaration
+// FuncDecl represents a function declaration (single or multi-result)
 type FuncDecl struct {
-	Token      lexer.Token // the return type token
-	ReturnType string      // "INT", "BYTE", "BOOL", "REAL"
-	Name       string
-	Params     []ProcParam
-	Body       []Statement // local decls + body statements (VALOF form), empty for IS form
-	ResultExpr Expression  // the return expression (from IS or RESULT)
+	Token       lexer.Token    // the return type token
+	ReturnTypes []string       // return types: ["INT"], ["INT", "INT"], etc.
+	Name        string
+	Params      []ProcParam
+	Body        []Statement    // local decls + body statements (VALOF form), empty for IS form
+	ResultExprs []Expression   // return expressions (from IS or RESULT)
 }
 
 func (f *FuncDecl) statementNode()       {}

--- a/codegen/e2e_proc_func_test.go
+++ b/codegen/e2e_proc_func_test.go
@@ -180,6 +180,52 @@ SEQ
 	}
 }
 
+func TestE2E_MultiResultFunction(t *testing.T) {
+	occam := `INT, INT FUNCTION swap(VAL INT a, VAL INT b)
+  INT x, y:
+  VALOF
+    SEQ
+      x := b
+      y := a
+    RESULT x, y
+
+SEQ
+  INT p, q:
+  p, q := swap(10, 20)
+  print.int(p)
+  print.int(q)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "20\n10\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_MultiResultFunctionThreeValues(t *testing.T) {
+	occam := `INT, INT, INT FUNCTION rotate(VAL INT a, VAL INT b, VAL INT c)
+  INT x, y, z:
+  VALOF
+    SEQ
+      x := b
+      y := c
+      z := a
+    RESULT x, y, z
+
+SEQ
+  INT p, q, r:
+  p, q, r := rotate(1, 2, 3)
+  print.int(p)
+  print.int(q)
+  print.int(r)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "2\n3\n1\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
 func TestE2E_NonValAbbreviation(t *testing.T) {
 	occam := `SEQ
   INT x:


### PR DESCRIPTION
## Summary
- Add support for multi-result FUNCTIONs (`INT, INT FUNCTION f(...)`) with comma-separated `RESULT` expressions, mapping to Go multi-return functions
- Add multi-assignment syntax (`a, b := func(args)`) for calling multi-result functions
- New `MultiAssignment` AST node and updated `FuncDecl` to use `ReturnTypes []string` and `ResultExprs []Expression`

## Test plan
- [x] Existing parser tests updated and passing (`TestFuncDeclIS`, `TestFuncDeclValof`)
- [x] New parser tests: `TestMultiResultFuncDecl`, `TestMultiAssignment`
- [x] New e2e tests: `TestE2E_MultiResultFunction` (2-value swap), `TestE2E_MultiResultFunctionThreeValues` (3-value rotate)
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)