### PR TITLE
Add array slice support ([arr FROM n FOR m] syntax)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ Six packages, one pipeline:
 | `#COMMENT`/`#PRAGMA`/`#USE` | Ignored (blank line) |
 | `#FF`, `#80000000` | `0xFF`, `0x80000000` (hex integer literals) |
 | `SIZE arr` / `SIZE "str"` | `len(arr)` / `len("str")` |
+| `[arr FROM n FOR m]` | `arr[n : n+m]` (array slice) |
+| `[arr FROM n FOR m] := src` | `copy(arr[n:n+m], src)` (slice assignment) |
 
 ## Key Parser Patterns
 
@@ -143,10 +145,11 @@ Typical workflow for a new language construct:
 3. **Parser** (`parser/parser.go`): Add case to `parseStatement()` switch; implement parse function
 4. **Codegen** (`codegen/codegen.go`): Add case to `generateStatement()` or `generateExpression()`; implement generation. If the new construct needs an import (sync, fmt, time), add a `containsX()` scanner
 5. **Tests**: Add parser unit tests in `parser/parser_test.go`, codegen unit tests in `codegen/codegen_test.go`, and e2e tests in `codegen/e2e_test.go`
+6. **Documentation**: Update TODO.md to reflect support for the new feature.
 
 ## What's Implemented
 
-Preprocessor (`#IF`/`#ELSE`/`#ENDIF`/`#DEFINE`/`#INCLUDE` with search paths, include guards, `#COMMENT`/`#PRAGMA`/`#USE` ignored), module file generation from SConscript (`gen-module` subcommand), SEQ, PAR, IF, WHILE, CASE, ALT (with guards and timer timeouts), SKIP, STOP, variable/array/channel/timer declarations, abbreviations (`VAL INT x IS 42:`, `INT y IS z:`), assignments (simple and indexed), channel send/receive, channel arrays (`[n]CHAN OF TYPE` with indexed send/receive and `[]CHAN OF TYPE` proc params), PROC (with VAL, reference, CHAN, []CHAN, and open array `[]TYPE` params), channel direction restrictions (`CHAN OF INT c?` → `<-chan int`, `CHAN OF INT c!` → `chan<- int`), FUNCTION (IS and VALOF forms, including multi-result `INT, INT FUNCTION` with `RESULT a, b`), multi-assignment (`a, b := func(...)`), KRoC-style colon terminators on PROC/FUNCTION (optional), replicators on SEQ and PAR, arithmetic/comparison/logical/AFTER/bitwise operators, type conversions (`INT expr`, `BYTE expr`, `REAL32 expr`, `REAL64 expr`, etc.), REAL32/REAL64 types, hex integer literals (`#FF`, `#80000000`), string literals, byte literals (`'A'`, `'*n'` with occam escape sequences), built-in print procedures, protocols (simple, sequential, and variant), record types (with field access via bracket syntax), SIZE operator.
+Preprocessor (`#IF`/`#ELSE`/`#ENDIF`/`#DEFINE`/`#INCLUDE` with search paths, include guards, `#COMMENT`/`#PRAGMA`/`#USE` ignored), module file generation from SConscript (`gen-module` subcommand), SEQ, PAR, IF, WHILE, CASE, ALT (with guards and timer timeouts), SKIP, STOP, variable/array/channel/timer declarations, abbreviations (`VAL INT x IS 42:`, `INT y IS z:`), assignments (simple and indexed), channel send/receive, channel arrays (`[n]CHAN OF TYPE` with indexed send/receive and `[]CHAN OF TYPE` proc params), PROC (with VAL, reference, CHAN, []CHAN, and open array `[]TYPE` params), channel direction restrictions (`CHAN OF INT c?` → `<-chan int`, `CHAN OF INT c!` → `chan<- int`), FUNCTION (IS and VALOF forms, including multi-result `INT, INT FUNCTION` with `RESULT a, b`), multi-assignment (`a, b := func(...)`), KRoC-style colon terminators on PROC/FUNCTION (optional), replicators on SEQ and PAR, arithmetic/comparison/logical/AFTER/bitwise operators, type conversions (`INT expr`, `BYTE expr`, `REAL32 expr`, `REAL64 expr`, etc.), REAL32/REAL64 types, hex integer literals (`#FF`, `#80000000`), string literals, byte literals (`'A'`, `'*n'` with occam escape sequences), built-in print procedures, protocols (simple, sequential, and variant), record types (with field access via bracket syntax), SIZE operator, array slices (`[arr FROM n FOR m]` with slice assignment).
 
 ## Not Yet Implemented
 

--- a/TODO.md
+++ b/TODO.md
@@ -80,7 +80,7 @@ These features are needed to transpile the KRoC course module (`kroc/modules/cou
 | **Checked arithmetic** | `TIMES`, `PLUS`, `MINUS` — modular (wrapping) arithmetic operators. | demo_cycles.occ, random.occ, utils.occ |
 | **`MOSTNEG INT`** | Most-negative integer constant. | utils.occ |
 | **`INITIAL` declarations** | `INITIAL INT i IS 0:` — mutable variable with initial value. | stringbuf.occ |
-| **Array slices** | `[a FROM n FOR m]` — sub-array references. | string.occ, stringbuf.occ, float_io.occ |
+| ~~**Array slices**~~ | ~~`[a FROM n FOR m]` — sub-array references.~~ **DONE** | string.occ, stringbuf.occ, float_io.occ |
 | **Replicator STEP** | `SEQ i = n FOR m STEP -1` — step value in replicators. | stringbuf.occ |
 | **Multi-assignment** | `a, b := x, y` — parallel assignment to multiple variables. | stringbuf.occ, utils.occ |
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -54,12 +54,13 @@ type ArrayDecl struct {
 func (a *ArrayDecl) statementNode()       {}
 func (a *ArrayDecl) TokenLiteral() string { return a.Token.Literal }
 
-// Assignment represents an assignment: x := 5 or arr[i] := 5
+// Assignment represents an assignment: x := 5 or arr[i] := 5 or [arr FROM n FOR m] := value
 type Assignment struct {
-	Token lexer.Token // the := token
-	Name  string      // variable name
-	Index Expression  // optional: index expression for arr[i] := x (nil for simple assignments)
-	Value Expression  // the value being assigned
+	Token       lexer.Token // the := token
+	Name        string      // variable name
+	Index       Expression  // optional: index expression for arr[i] := x (nil for simple assignments)
+	SliceTarget *SliceExpr  // optional: slice target for [arr FROM n FOR m] := value
+	Value       Expression  // the value being assigned
 }
 
 func (a *Assignment) statementNode()       {}
@@ -448,6 +449,17 @@ type RecordField struct {
 
 func (rd *RecordDecl) statementNode()       {}
 func (rd *RecordDecl) TokenLiteral() string { return rd.Token.Literal }
+
+// SliceExpr represents an array slice: [arr FROM start FOR length]
+type SliceExpr struct {
+	Token  lexer.Token // the [ token
+	Array  Expression  // the array being sliced
+	Start  Expression  // start index
+	Length Expression  // number of elements
+}
+
+func (se *SliceExpr) expressionNode()      {}
+func (se *SliceExpr) TokenLiteral() string { return se.Token.Literal }
 
 // Abbreviation represents an abbreviation: VAL INT x IS 42: or INT y IS z:
 type Abbreviation struct {

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -842,6 +842,23 @@ func (g *Generator) occamTypeToGo(occamType string) string {
 func (g *Generator) generateAssignment(assign *ast.Assignment) {
 	g.builder.WriteString(strings.Repeat("\t", g.indent))
 
+	if assign.SliceTarget != nil {
+		// Slice assignment: [arr FROM start FOR length] := value
+		// Maps to: copy(arr[start : start + length], value)
+		g.write("copy(")
+		g.generateExpression(assign.SliceTarget.Array)
+		g.write("[")
+		g.generateExpression(assign.SliceTarget.Start)
+		g.write(" : ")
+		g.generateExpression(assign.SliceTarget.Start)
+		g.write(" + ")
+		g.generateExpression(assign.SliceTarget.Length)
+		g.write("], ")
+		g.generateExpression(assign.Value)
+		g.write(")\n")
+		return
+	}
+
 	if assign.Index != nil {
 		// Check if this is a record field access
 		if _, ok := g.recordVars[assign.Name]; ok {
@@ -1335,6 +1352,15 @@ func (g *Generator) generateExpression(expr ast.Expression) {
 		g.generateExpression(e.Left)
 		g.write("[")
 		g.generateExpression(e.Index)
+		g.write("]")
+	case *ast.SliceExpr:
+		g.generateExpression(e.Array)
+		g.write("[")
+		g.generateExpression(e.Start)
+		g.write(" : ")
+		g.generateExpression(e.Start)
+		g.write(" + ")
+		g.generateExpression(e.Length)
 		g.write("]")
 	case *ast.FuncCall:
 		g.generateFuncCallExpr(e)

--- a/codegen/e2e_array_test.go
+++ b/codegen/e2e_array_test.go
@@ -167,6 +167,78 @@ func TestE2E_SizeString(t *testing.T) {
 	}
 }
 
+func TestE2E_SliceAsArg(t *testing.T) {
+	// Pass an array slice to a PROC expecting an open array param
+	occam := `PROC printarray(VAL []INT arr)
+  SEQ i = 0 FOR SIZE arr
+    print.int(arr[i])
+SEQ
+  [5]INT nums:
+  SEQ i = 0 FOR 5
+    nums[i] := (i + 1) * 10
+  printarray([nums FROM 1 FOR 3])
+`
+	output := transpileCompileRun(t, occam)
+	expected := "20\n30\n40\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_SliceAssignment(t *testing.T) {
+	// Copy elements within an array using slice assignment
+	occam := `SEQ
+  [6]INT arr:
+  SEQ i = 0 FOR 6
+    arr[i] := i + 1
+  [arr FROM 3 FOR 3] := [arr FROM 0 FOR 3]
+  SEQ i = 0 FOR 6
+    print.int(arr[i])
+`
+	output := transpileCompileRun(t, occam)
+	expected := "1\n2\n3\n1\n2\n3\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_SliceSize(t *testing.T) {
+	// SIZE of a slice expression
+	occam := `SEQ
+  [10]INT arr:
+  INT n:
+  n := SIZE [arr FROM 2 FOR 5]
+  print.int(n)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "5\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_SliceFromZero(t *testing.T) {
+	// Slice starting from index 0 passed to a VAL open array proc
+	occam := `PROC printsum(VAL []INT arr)
+  SEQ
+    INT total:
+    total := 0
+    SEQ i = 0 FOR SIZE arr
+      total := total + arr[i]
+    print.int(total)
+SEQ
+  [5]INT arr:
+  SEQ i = 0 FOR 5
+    arr[i] := i + 1
+  printsum([arr FROM 0 FOR 3])
+`
+	output := transpileCompileRun(t, occam)
+	expected := "6\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
 func TestE2E_OpenArrayParam(t *testing.T) {
 	occam := `PROC printarray(VAL []INT arr)
   SEQ i = 0 FOR SIZE arr

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -58,6 +58,7 @@ const (
 	ELSE
 	WHILE
 	FOR
+	FROM
 	PROC
 	FUNC
 	FUNCTION
@@ -138,6 +139,7 @@ var tokenNames = map[TokenType]string{
 	ELSE:      "ELSE",
 	WHILE:     "WHILE",
 	FOR:       "FOR",
+	FROM:      "FROM",
 	PROC:      "PROC",
 	FUNC:      "FUNC",
 	FUNCTION:  "FUNCTION",
@@ -176,6 +178,7 @@ var keywords = map[string]TokenType{
 	"ELSE":  ELSE,
 	"WHILE": WHILE,
 	"FOR":   FOR,
+	"FROM":  FROM,
 	"PROC":  PROC,
 	"FUNC":     FUNC,
 	"FUNCTION": FUNCTION,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -400,6 +400,11 @@ func (p *Parser) parseArrayDecl() ast.Statement {
 	p.nextToken()
 	size := p.parseExpression(LOWEST)
 
+	// Check if this is a slice assignment: [arr FROM start FOR length] := value
+	if p.peekTokenIs(lexer.FROM) {
+		return p.parseSliceAssignment(lbracketToken, size)
+	}
+
 	// Expect ]
 	if !p.expectPeek(lexer.RBRACKET) {
 		return nil
@@ -485,6 +490,45 @@ func (p *Parser) parseArrayDecl() ast.Statement {
 	}
 
 	return decl
+}
+
+// parseSliceAssignment parses [arr FROM start FOR length] := value
+// Called from parseArrayDecl when FROM is detected after the array expression.
+// lbracketToken is the [ token, arrayExpr is the already-parsed array expression.
+func (p *Parser) parseSliceAssignment(lbracketToken lexer.Token, arrayExpr ast.Expression) ast.Statement {
+	p.nextToken() // consume FROM
+	p.nextToken() // move to start expression
+	startExpr := p.parseExpression(LOWEST)
+
+	if !p.expectPeek(lexer.FOR) {
+		return nil
+	}
+	p.nextToken() // move to length expression
+	lengthExpr := p.parseExpression(LOWEST)
+
+	if !p.expectPeek(lexer.RBRACKET) {
+		return nil
+	}
+
+	if !p.expectPeek(lexer.ASSIGN) {
+		return nil
+	}
+
+	assignToken := p.curToken
+	p.nextToken() // move past :=
+
+	value := p.parseExpression(LOWEST)
+
+	return &ast.Assignment{
+		Token: assignToken,
+		SliceTarget: &ast.SliceExpr{
+			Token:  lbracketToken,
+			Array:  arrayExpr,
+			Start:  startExpr,
+			Length: lengthExpr,
+		},
+		Value: value,
+	}
 }
 
 func (p *Parser) parseIndexedOperation() ast.Statement {
@@ -2239,6 +2283,30 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 			Token:    token,
 			Operator: "~",
 			Right:    p.parseExpression(PREFIX),
+		}
+	case lexer.LBRACKET:
+		// Slice expression: [arr FROM start FOR length]
+		lbracket := p.curToken
+		p.nextToken() // move past [
+		arrayExpr := p.parseExpression(LOWEST)
+		if !p.expectPeek(lexer.FROM) {
+			return nil
+		}
+		p.nextToken() // move past FROM
+		startExpr := p.parseExpression(LOWEST)
+		if !p.expectPeek(lexer.FOR) {
+			return nil
+		}
+		p.nextToken() // move past FOR
+		lengthExpr := p.parseExpression(LOWEST)
+		if !p.expectPeek(lexer.RBRACKET) {
+			return nil
+		}
+		left = &ast.SliceExpr{
+			Token:  lbracket,
+			Array:  arrayExpr,
+			Start:  startExpr,
+			Length: lengthExpr,
 		}
 	case lexer.SIZE_KW:
 		token := p.curToken


### PR DESCRIPTION
## Summary

- Add `FROM` keyword to the lexer and `SliceExpr` AST node for representing array slices
- Parse `[arr FROM start FOR length]` in both expression context (e.g. proc args, RHS of assignment) and statement context (slice assignment LHS)
- Generate Go slice notation `arr[start : start + length]` for reads and `copy(dst, src)` for slice assignments

## Mapping

| Occam | Go |
|---|---|
| `[arr FROM n FOR m]` | `arr[n : n+m]` |
| `[arr FROM n FOR m] := src` | `copy(arr[n:n+m], src)` |

## Test plan

- [x] `TestE2E_SliceAsArg` — pass slice to open array param proc
- [x] `TestE2E_SliceAssignment` — copy within array via slice assignment
- [x] `TestE2E_SliceSize` — `SIZE` on a slice expression
- [x] `TestE2E_SliceFromZero` — slice from index 0 as proc argument
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)