### PR TITLE
Fix infinite loops in parser and support nested IF

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -205,6 +205,7 @@ type IfStatement struct {
 type IfChoice struct {
 	Condition Expression
 	Body      []Statement
+	NestedIf  *IfStatement // non-nil when this choice is a nested/replicated IF
 }
 
 func (i *IfStatement) statementNode()       {}


### PR DESCRIPTION
## Summary

- **Fix OOM-inducing infinite loops** in the parser that occurred when transpiling real-world occam code (e.g., KRoC course module). Two root causes: (1) nested/replicated `IF` within `IF` blocks caused `parseExpression` to fail without advancing the cursor, and (2) unknown type declarations in variant `? CASE` blocks caused the same stall pattern.
- **Support nested IF constructs** — both plain nested `IF` (choices inlined into parent chain) and replicated `IF i = 0 FOR n` (emitted as a loop with `_ifmatched` flag). This is a common occam idiom for searching arrays.
- **Add progress guards** to all parser loops (`IF`, `CASE`, `ALT`, variant receive) as a safety net against future infinite loop regressions.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] 4 new e2e tests: replicated IF with default, no-match fallthrough, preceding normal choice, non-replicated nested IF
- [x] All KRoC course module `.occ` files terminate without hanging (previously 4 of 9 caused OOM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)