### PR TITLE
Support full course module transpilation including float_io.occ

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,7 @@
 - **Channel arrays** — `[n]CHAN OF TYPE cs:` with indexed send/receive and `[]CHAN OF TYPE` proc params
 - **Channel direction** — `CHAN OF INT c?` (receive-only) and `CHAN OF INT c!` (send-only); direction annotations at call sites (`out!`, `in?`) accepted and ignored
 - **Timers** — `TIMER tim:` with reads and `AFTER` expressions
-- **Abbreviations** — `VAL INT x IS 1:`, `INT y IS z:` — named constants and aliases
+- **Abbreviations** — `VAL INT x IS 1:`, `INT y IS z:`, untyped `VAL x IS expr:` — named constants and aliases
 - **INITIAL declarations** — `INITIAL INT x IS 42:` — mutable variables with initial values
 - **Byte literals** — `'A'`, `'0'` with occam escape sequences (`*n`, `*c`, `*t`)
 - **Hex integer literals** — `#FF`, `#80000000`
@@ -49,7 +49,9 @@
 - **MOSTNEG/MOSTPOS** — Type min/max constants for INT, BYTE, REAL32, REAL64
 - **SIZE operator** — `SIZE arr`, `SIZE "str"` maps to `len()`
 - **Array slices** — `[arr FROM n FOR m]` with slice assignment
+- **Array literals** — `[1, 2, 3]` — inline array/table expressions
 - **Multi-assignment** — `a, b := f(...)` including indexed targets like `x[0], x[1] := x[1], x[0]`
+- **Multi-line expression continuation** — Binary operators and `:=` at end of line continue expression on next line
 
 ### Protocols
 - **Simple** — `PROTOCOL SIG IS INT` (type alias)
@@ -58,6 +60,11 @@
 
 ### Records
 - **RECORD** — Struct types with field access via bracket syntax (`p[x]`)
+
+### Type Reinterpretation & Intrinsics
+- **RETYPES** — Bit-level type reinterpretation (`VAL INT X RETYPES X :` for float32→int, `VAL [2]INT X RETYPES X :` for float64→int pair)
+- **Transputer intrinsics** — `LONGPROD`, `LONGDIV`, `LONGSUM`, `LONGDIFF`, `NORMALISE`, `SHIFTLEFT`, `SHIFTRIGHT` — extended-precision arithmetic as Go helper functions
+- **CAUSEERROR** — Error-raising primitive, maps to `panic("CAUSEERROR")`
 
 ### Preprocessor
 - **`#IF` / `#ELSE` / `#ENDIF`** — Conditional compilation with `TRUE`, `FALSE`, `DEFINED()`, `NOT`, equality
@@ -89,8 +96,5 @@
 | **PRI ALT / PRI PAR** | Priority variants of ALT and PAR. |
 | **PLACED PAR** | Assigning processes to specific hardware. |
 | **PORT OF** | Hardware port mapping. |
-| **`RETYPES`** | Type punning / reinterpret cast (`VAL INT X RETYPES X :`). Used in float_io.occ. |
-| **`CAUSEERROR ()`** | Built-in error-raising primitive. Used in float_io.occ. |
-| **Transputer intrinsics** | `LONGPROD`, `LONGDIV`, `LONGSUM`, `LONGDIFF`, `NORMALISE`, `SHIFTLEFT`, `SHIFTRIGHT`. Used in float_io.occ. |
 | **`VAL []BYTE` abbreviations** | `VAL []BYTE cmap IS "0123456789ABCDEF":` — named string constants. |
 | **`#PRAGMA DEFINED`** | Compiler hint to suppress definedness warnings. Can be ignored. |

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -494,3 +494,27 @@ type Abbreviation struct {
 
 func (a *Abbreviation) statementNode()       {}
 func (a *Abbreviation) TokenLiteral() string { return a.Token.Literal }
+
+// ArrayLiteral represents an array literal expression: [expr1, expr2, ...]
+type ArrayLiteral struct {
+	Token    lexer.Token  // the [ token
+	Elements []Expression // the elements
+}
+
+func (al *ArrayLiteral) expressionNode()      {}
+func (al *ArrayLiteral) TokenLiteral() string { return al.Token.Literal }
+
+// RetypesDecl represents a RETYPES declaration:
+// VAL INT X RETYPES X : or VAL [2]INT X RETYPES X :
+type RetypesDecl struct {
+	Token      lexer.Token // the VAL token
+	IsVal      bool        // always true for now (VAL ... RETYPES ...)
+	TargetType string      // "INT", "REAL32", etc.
+	IsArray    bool        // true for [n]TYPE
+	ArraySize  Expression  // array size when IsArray
+	Name       string      // target variable name
+	Source     string      // source variable name
+}
+
+func (r *RetypesDecl) statementNode()       {}
+func (r *RetypesDecl) TokenLiteral() string { return r.Token.Literal }

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -612,3 +612,47 @@ func TestMultiAssignmentMixed(t *testing.T) {
 		t.Errorf("expected 'a, x[0] = 1, 2' in output, got:\n%s", output)
 	}
 }
+
+func TestArrayLiteralCodegen(t *testing.T) {
+	input := `VAL x IS [10, 20, 30] :
+`
+	output := transpile(t, input)
+	if !strings.Contains(output, "[]int{10, 20, 30}") {
+		t.Errorf("expected '[]int{10, 20, 30}' in output, got:\n%s", output)
+	}
+}
+
+func TestUntypedValCodegen(t *testing.T) {
+	input := `VAL x IS 42 :
+PROC dummy()
+  SKIP
+:
+`
+	output := transpile(t, input)
+	if !strings.Contains(output, "var x = 42") {
+		t.Errorf("expected 'var x = 42' in output, got:\n%s", output)
+	}
+}
+
+func TestCAUSEERROR(t *testing.T) {
+	input := `PROC main()
+  CAUSEERROR()
+:
+`
+	output := transpile(t, input)
+	if !strings.Contains(output, `panic("CAUSEERROR")`) {
+		t.Errorf("expected 'panic(\"CAUSEERROR\")' in output, got:\n%s", output)
+	}
+}
+
+func TestGoIdentByteReserved(t *testing.T) {
+	input := `PROC main()
+  BYTE byte:
+  byte := 65
+:
+`
+	output := transpile(t, input)
+	if !strings.Contains(output, "_byte") {
+		t.Errorf("expected '_byte' in output, got:\n%s", output)
+	}
+}

--- a/codegen/e2e_phase2_test.go
+++ b/codegen/e2e_phase2_test.go
@@ -1,0 +1,102 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/codeassociates/occam2go/lexer"
+	"github.com/codeassociates/occam2go/parser"
+)
+
+func TestE2E_UntypedValAbbreviation(t *testing.T) {
+	occam := `SEQ
+  VAL x IS 42 :
+  print.int(x)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "42\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_ArrayLiteralIndexing(t *testing.T) {
+	occam := `SEQ
+  VAL arr IS [10, 20, 30] :
+  print.int(arr[1])
+`
+	output := transpileCompileRun(t, occam)
+	expected := "20\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_MultiLineBooleanIF(t *testing.T) {
+	occam := `SEQ
+  INT x:
+  x := 1
+  IF
+    (x > 0) AND
+      (x < 10)
+      print.int(x)
+    TRUE
+      print.int(0)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "1\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_CAUSEERROR(t *testing.T) {
+	occamSource := `PROC main()
+  CAUSEERROR()
+:
+`
+	// Transpile
+	l := lexer.New(occamSource)
+	p := parser.New(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) > 0 {
+		for _, err := range p.Errors() {
+			t.Errorf("parser error: %s", err)
+		}
+		t.FailNow()
+	}
+
+	gen := New()
+	goCode := gen.Generate(program)
+
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "occam2go-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Write Go source
+	goFile := filepath.Join(tmpDir, "main.go")
+	if err := os.WriteFile(goFile, []byte(goCode), 0644); err != nil {
+		t.Fatalf("failed to write Go file: %v", err)
+	}
+
+	// Compile
+	binFile := filepath.Join(tmpDir, "main")
+	compileCmd := exec.Command("go", "build", "-o", binFile, goFile)
+	compileOutput, err := compileCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compilation failed: %v\nOutput: %s\nGo code:\n%s", err, compileOutput, goCode)
+	}
+
+	// Run — expect non-zero exit code (panic)
+	runCmd := exec.Command(binFile)
+	err = runCmd.Run()
+	if err == nil {
+		t.Fatalf("expected CAUSEERROR to cause a non-zero exit, but program exited successfully")
+	}
+}

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -90,6 +90,7 @@ const (
 	MOSTNEG_KW
 	MOSTPOS_KW
 	INITIAL
+	RETYPES  // RETYPES (bit-level type reinterpretation)
 	PLUS_KW  // PLUS (modular addition keyword, distinct from + symbol)
 	MINUS_KW // MINUS (modular subtraction keyword, distinct from - symbol)
 	TIMES    // TIMES (modular multiplication keyword)
@@ -178,6 +179,7 @@ var tokenNames = map[TokenType]string{
 	MOSTNEG_KW: "MOSTNEG",
 	MOSTPOS_KW: "MOSTPOS",
 	INITIAL:    "INITIAL",
+	RETYPES:    "RETYPES",
 	PLUS_KW:    "PLUS",
 	MINUS_KW:   "MINUS",
 	TIMES:      "TIMES",
@@ -224,6 +226,7 @@ var keywords = map[string]TokenType{
 	"MOSTNEG":  MOSTNEG_KW,
 	"MOSTPOS":  MOSTPOS_KW,
 	"INITIAL":  INITIAL,
+	"RETYPES":  RETYPES,
 	"PLUS":     PLUS_KW,
 	"MINUS":    MINUS_KW,
 	"TIMES":    TIMES,


### PR DESCRIPTION
## Summary

- Implement Phase 2 features to transpile the complete KRoC course module with `float_io.occ` (598 parse errors → 0, `go vet` clean)
- Add RETYPES declarations, transputer intrinsic helpers, array literals, untyped VAL abbreviations, multi-line expression continuation, and CAUSEERROR support
- Add 13 new tests (5 parser, 4 codegen, 4 e2e) covering all new constructs

### Lexer
- Bracket `[`/`]` NEWLINE suppression via `parenDepth`
- `RETYPES` keyword token
- Multi-line expression continuation: `isContinuationOp()` suppresses NEWLINE/INDENT/DEDENT after binary operators and `:=`

### AST
- `ArrayLiteral` expression node (`[1, 2, 3]`)
- `RetypesDecl` statement node (`VAL INT X RETYPES X :`)

### Parser
- Untyped VAL abbreviations (`VAL name IS expr :`)
- Array literal expressions (`[e1, e2, ...]`)
- RETYPES declarations (single `VAL INT X RETYPES X :` and array `VAL [2]INT X RETYPES X :`)

### Codegen
- Array literal → `[]int{...}`
- Untyped VAL → `var x = expr`
- RETYPES with parameter renaming for same-name shadowing (Go can't `:=` redeclare params)
- 7 transputer intrinsic Go helpers (LONGPROD, LONGDIV, LONGSUM, LONGDIFF, NORMALISE, SHIFTRIGHT, SHIFTLEFT)
- CAUSEERROR → `panic("CAUSEERROR")`
- Go reserved word escaping (`byte` → `_byte`, etc.)
- Scoped nested proc signature collection (fixes same-named nested procs)
- Fixed-size array params → slices for Go compatibility
- Abbreviation `_ = name` suppression in function bodies

## Test plan

- [x] `go test ./...` — all existing + 13 new tests pass
- [x] `go vet /tmp/course_out.go` — full course.module transpiles cleanly
- [x] `go vet` on `course_nofloat.module` — regression check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)