### PR TITLE
Enable running course module programs end-to-end

### DIFF
--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -250,6 +250,17 @@ func TestStringLiteral(t *testing.T) {
 	}
 }
 
+func TestStringEscapeCodegen(t *testing.T) {
+	input := `x := "hello*c*n"
+`
+	output := transpile(t, input)
+
+	// The *c*n should become \r\n in the Go output (via %q formatting)
+	if !strings.Contains(output, `x = "hello\r\n"`) {
+		t.Errorf("expected string with \\r\\n escape, got:\n%s", output)
+	}
+}
+
 func TestByteLiteral(t *testing.T) {
 	input := "x := 'A'\n"
 	output := transpile(t, input)

--- a/codegen/e2e_course_test.go
+++ b/codegen/e2e_course_test.go
@@ -1,0 +1,96 @@
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/codeassociates/occam2go/lexer"
+	"github.com/codeassociates/occam2go/parser"
+	"github.com/codeassociates/occam2go/preproc"
+)
+
+// transpileCompileRunWithDefines is like transpileCompileRunFromFile but
+// accepts preprocessor defines (e.g., TARGET.BITS.PER.WORD=32).
+func transpileCompileRunWithDefines(t *testing.T, mainFile string, includePaths []string, defines map[string]string) string {
+	t.Helper()
+
+	pp := preproc.New(preproc.WithIncludePaths(includePaths), preproc.WithDefines(defines))
+	expanded, err := pp.ProcessFile(mainFile)
+	if err != nil {
+		t.Fatalf("preprocessor error: %v", err)
+	}
+	if len(pp.Errors()) > 0 {
+		for _, e := range pp.Errors() {
+			t.Errorf("preprocessor warning: %s", e)
+		}
+	}
+
+	// Transpile
+	l := lexer.New(expanded)
+	p := parser.New(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) > 0 {
+		for _, err := range p.Errors() {
+			t.Errorf("parser error: %s", err)
+		}
+		t.FailNow()
+	}
+
+	gen := New()
+	goCode := gen.Generate(program)
+
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "occam2go-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Write Go source
+	goFile := filepath.Join(tmpDir, "main.go")
+	if err := os.WriteFile(goFile, []byte(goCode), 0644); err != nil {
+		t.Fatalf("failed to write Go file: %v", err)
+	}
+
+	// Compile
+	binFile := filepath.Join(tmpDir, "main")
+	compileCmd := exec.Command("go", "build", "-o", binFile, goFile)
+	compileOutput, err := compileCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compilation failed: %v\nOutput: %s\nGo code:\n%s", err, compileOutput, goCode)
+	}
+
+	// Run
+	runCmd := exec.Command(binFile)
+	output, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("execution failed: %v\nOutput: %s", err, output)
+	}
+
+	return string(output)
+}
+
+func TestE2E_HelloWorldCourseModule(t *testing.T) {
+	// Find the kroc directory relative to this test file
+	krocDir := filepath.Join("..", "kroc", "modules", "course")
+	mainFile := filepath.Join(krocDir, "examples", "hello_world.occ")
+	includeDir := filepath.Join(krocDir, "libsrc")
+
+	// Check that the files exist
+	if _, err := os.Stat(mainFile); os.IsNotExist(err) {
+		t.Skip("kroc course module not found, skipping")
+	}
+
+	defines := map[string]string{
+		"TARGET.BITS.PER.WORD": "32",
+	}
+
+	output := transpileCompileRunWithDefines(t, mainFile, []string{includeDir}, defines)
+	expected := "Hello World\r\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}

--- a/examples/course_hello.occ
+++ b/examples/course_hello.occ
@@ -1,0 +1,36 @@
+-- Hello World example using the KRoC course module.
+--
+-- This demonstrates the standard occam entry point pattern:
+-- a PROC with three CHAN BYTE parameters (keyboard, screen, error)
+-- wired to stdin, stdout, and stderr by the generated main() harness.
+--
+-- The course module provides utility PROCs such as out.string, out.int,
+-- and out.repeat for character-level I/O on byte channels.
+--
+-- To transpile and run:
+--   ./occam2go -I kroc/modules/course/libsrc \
+--              -D TARGET.BITS.PER.WORD=32     \
+--              -o hello.go examples/course_hello.occ
+--   go run hello.go
+
+#INCLUDE "course.module"
+
+PROC hello (CHAN BYTE keyboard?, screen!, error!)
+  SEQ
+    out.string ("Hello from occam2go!*c*n", 0, screen!)
+    out.string ("The answer is: ", 0, screen!)
+    out.int (42, 0, screen!)
+    out.string ("*c*n", 0, screen!)
+    out.repeat ('-', 30, screen!)
+    out.string ("*c*n", 0, screen!)
+    out.string ("Counting: ", 0, screen!)
+    SEQ i = 1 FOR 5
+      SEQ
+        IF
+          i > 1
+            out.string (", ", 0, screen!)
+          TRUE
+            SKIP
+        out.int (i, 0, screen!)
+    out.string ("*c*n", 0, screen!)
+:


### PR DESCRIPTION
## Summary

- **String escape conversion**: Occam string escapes (`*c`, `*n`, `*t`, `*s`, `**`, `*'`, `*"`) are now converted to real bytes in the parser, so `"Hello World*c*n"` produces correct Go output (`"Hello World\r\n"`)
- **Main harness generation**: PROCs with the standard occam entry point signature `(CHAN BYTE keyboard?, screen!, error!)` automatically get a generated `func main()` that wires stdin/stdout/stderr to byte channels via buffered I/O goroutines
- **Example and docs**: Added `examples/course_hello.occ` and updated README with a walkthrough for transpiling and running programs that use the KRoC course module

## Test plan

- [x] `go test ./parser -run TestStringEscape` — parser converts all occam escape sequences correctly
- [x] `go test ./codegen -run TestStringEscapeCodegen` — codegen emits correct Go string with `\r\n`
- [x] `go test ./codegen -run TestE2E_HelloWorldCourseModule` — full pipeline: preprocess → transpile → compile → run hello_world.occ, verify output
- [x] `go test ./...` — all existing tests still pass
- [x] Course module `go vet` regression: `./occam2go -I kroc/modules/course/libsrc -D TARGET.BITS.PER.WORD=32 -o /tmp/course_out.go kroc/modules/course/libsrc/course.module && go vet /tmp/course_out.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)