### PR TITLE
Document gen-module regex-based limitation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Six packages, one pipeline:
    - `codegen_test.go` — Unit tests (transpile, check output strings)
    - `e2e_test.go` — End-to-end tests (transpile → `go build` → execute → check stdout)
 
-6. **`modgen/`** — Generates `.module` files from KRoC SConscript build files. Parses Python-based SConscript to extract source lists and `OccamLibrary` calls.
+6. **`modgen/`** — Generates `.module` files from KRoC SConscript build files. Uses regex-based pattern matching (not Python execution) to extract `Split('''...''')` source lists and `OccamLibrary` calls. Only works with simple, declarative SConscript files; files using Python control flow (loops, conditionals) are not supported.
    - `modgen.go` — SConscript parser and module file generator
 
 7. **`main.go`** — CLI entry point wiring the pipeline together

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ A working example is provided in `examples/include_demo.occ` with `examples/math
 
 ### Generating Module Files from KRoC SConscript
 
-The KRoC project defines module composition in SConscript (Python) build files. The `gen-module` subcommand parses these to generate `.module` files:
+The KRoC project defines module composition in SConscript (Python) build files. The `gen-module` subcommand extracts source file lists from these to generate `.module` files:
 
 ```bash
 # Clone the KRoC repository (one-time setup)
@@ -413,6 +413,8 @@ The KRoC project defines module composition in SConscript (Python) build files. 
 # Generate a module file from SConscript
 ./occam2go gen-module kroc/modules/course/libsrc/SConscript
 ```
+
+**Limitation:** `gen-module` uses regex-based pattern matching to extract `Split('''...''')` variable assignments and `OccamLibrary()` calls from SConscript files. It does not execute the Python code. This means it works with simple, declarative SConscript files (like `modules/course/libsrc/SConscript`) but cannot handle files that rely on Python control flow such as loops or conditionals (like the top-level `modules/course/SConscript`).
 
 This outputs:
 ```

--- a/modgen/modgen.go
+++ b/modgen/modgen.go
@@ -1,6 +1,11 @@
 // Package modgen generates .module files from KRoC SConscript build files.
-// It parses the Python-based SConscript to extract source file lists and
-// OccamLibrary calls, then produces an occam module file with include guards.
+// It uses regex-based pattern matching to extract Split('''...''') variable
+// assignments and OccamLibrary() calls, then produces an occam module file
+// with include guards.
+//
+// Note: This does not execute the Python code in SConscript files, so it only
+// works with simple, declarative SConscript files. Files that use Python
+// control flow (loops, conditionals, etc.) are not supported.
 package modgen
 
 import (


### PR DESCRIPTION
## Summary
- Clarifies that `gen-module` uses regex-based pattern matching (not Python execution) to extract `Split('''...''')` assignments and `OccamLibrary()` calls from SConscript files
- Documents that it only works with simple, declarative SConscript files and cannot handle Python control flow (loops, conditionals)
- Updates README.md, CLAUDE.md, and the `modgen` package doc comment

Closes #37

## Test plan
- [x] Documentation-only change, no code behavior modified
- [x] `go build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)