### PR TITLE
Fix typed abbreviations losing declared type

### DIFF
--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -677,11 +677,14 @@ func TestAbbreviation(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"VAL INT x IS 42:\n", "x := 42"},
-		{"VAL BOOL flag IS TRUE:\n", "flag := true"},
-		{"INT y IS z:\n", "y := z"},
-		{"INITIAL INT x IS 42:\n", "x := 42"},
-		{"INITIAL BOOL done IS FALSE:\n", "done := false"},
+		{"VAL INT x IS 42:\n", "var x int = 42"},
+		{"VAL BOOL flag IS TRUE:\n", "var flag bool = true"},
+		{"INT y IS z:\n", "var y int = z"},
+		{"INITIAL INT x IS 42:\n", "var x int = 42"},
+		{"INITIAL BOOL done IS FALSE:\n", "var done bool = false"},
+		{"VAL BYTE x IS 1:\n", "var x byte = 1"},
+		{"VAL INT16 x IS 42:\n", "var x int16 = 42"},
+		{"INITIAL BYTE done IS 0:\n", "var done byte = 0"},
 	}
 
 	for _, tt := range tests {

--- a/codegen/e2e_types_test.go
+++ b/codegen/e2e_types_test.go
@@ -675,3 +675,19 @@ func TestE2E_ComparisonToInt(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, output)
 	}
 }
+
+func TestE2E_TypedByteAbbreviation(t *testing.T) {
+	occam := `PROC main()
+  SEQ
+    VAL BYTE first.col IS 1:
+    BYTE col:
+    col := first.col
+    print.int(INT col)
+:
+`
+	output := transpileCompileRun(t, occam)
+	expected := "1\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}


### PR DESCRIPTION
## Summary
- Local `generateAbbreviation()` now emits `var name type = expr` when an explicit type is present, instead of always using `name := expr` which lets Go infer the type. This fixes type mismatches when e.g. `VAL BYTE first.col IS 1:` is later assigned to a `BYTE` variable.
- Adds `[]byte()` wrapping for string literals assigned to `[]BYTE` abbreviations at both package and local level, fixing compilation errors in the course module.

Fixes #52

## Test plan
- [x] Updated `TestAbbreviation` unit test expectations and added `VAL BYTE`, `VAL INT16`, `INITIAL BYTE` cases
- [x] Added `TestE2E_TypedByteAbbreviation` e2e test exercising the exact scenario from the issue
- [x] Full test suite passes (`go test ./...`)
- [x] Course module transpiles and passes `go vet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)