### PR TITLE
Fix channel array slices incompatible with direction-restricted params

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ Six packages, one pipeline:
 | `cs[i] ! 42` | `cs[i] <- 42` |
 | `cs[i] ? x` | `x = <-cs[i]` |
 | `PROC f([]CHAN OF INT cs)` | `func f(cs []chan int)` |
+| `PROC f([]CHAN OF INT cs?)` | `func f(cs []chan int)` (direction dropped for array params) |
+| `PROC f([]CHAN OF INT cs!)` | `func f(cs []chan int)` (direction dropped for array params) |
 | `PROC f(CHAN OF INT c?)` | `func f(c <-chan int)` (input/receive-only) |
 | `PROC f(CHAN OF INT c!)` | `func f(c chan<- int)` (output/send-only) |
 | `f(out!, in?)` (call-site dir) | `f(out, in)` (direction annotations ignored) |

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -2036,7 +2036,7 @@ func (g *Generator) generateProcParams(params []ast.ProcParam) string {
 	for _, p := range params {
 		var goType string
 		if p.IsChanArray {
-			goType = "[]" + chanDirPrefix(p.ChanDir) + g.occamTypeToGo(p.ChanElemType)
+			goType = "[]chan " + g.occamTypeToGo(p.ChanElemType)
 		} else if p.IsChan {
 			goType = chanDirPrefix(p.ChanDir) + g.occamTypeToGo(p.ChanElemType)
 		} else if p.IsOpenArray {

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -620,11 +620,11 @@ func TestChanArrayDirParamGen(t *testing.T) {
 `
 	output := transpile(t, input)
 
-	if !strings.Contains(output, "cs []<-chan int") {
-		t.Errorf("expected '[]<-chan int' for input chan array, got:\n%s", output)
+	if !strings.Contains(output, "cs []chan int") {
+		t.Errorf("expected '[]chan int' for input chan array, got:\n%s", output)
 	}
-	if !strings.Contains(output, "out []chan<- int") {
-		t.Errorf("expected '[]chan<- int' for output chan array, got:\n%s", output)
+	if !strings.Contains(output, "out []chan int") {
+		t.Errorf("expected '[]chan int' for output chan array, got:\n%s", output)
 	}
 }
 

--- a/codegen/e2e_array_test.go
+++ b/codegen/e2e_array_test.go
@@ -306,3 +306,30 @@ func TestE2E_MultiAssignmentValues(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, output)
 	}
 }
+
+func TestE2E_ChanArrayDirParam(t *testing.T) {
+	// Channel arrays passed to direction-annotated params must compile
+	// (Go slices are not covariant, so direction is dropped for array params)
+	occam := `PROC sender([]CHAN OF INT out!)
+  SEQ i = 0 FOR SIZE out
+    out[i] ! i
+:
+PROC receiver([]CHAN OF INT in?)
+  SEQ i = 0 FOR SIZE in
+    INT v:
+    SEQ
+      in[i] ? v
+      print.int(v)
+:
+SEQ
+  [3]CHAN OF INT cs:
+  PAR
+    sender(cs)
+    receiver(cs)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "0\n1\n2\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}


### PR DESCRIPTION
## Summary
- Drop direction prefixes (`<-chan`, `chan<-`) from channel array params, generating `[]chan T` instead of `[]<-chan T` / `[]chan<- T`
- Go slices are not covariant, so `[]chan byte` cannot be assigned to `[]<-chan byte`, causing compilation failures when passing channel arrays to direction-annotated proc params
- Single-channel params (`CHAN OF INT c?`) continue to use direction prefixes since individual channels are covariant in Go

## Test plan
- [x] Updated `TestChanArrayDirParamGen` unit test to expect `[]chan int`
- [x] Added `TestE2E_ChanArrayDirParam` e2e test (sender/receiver with direction-annotated `[]CHAN OF INT` params)
- [x] Full test suite passes (`go test ./...`)
- [x] Course module regression check passes
- [x] `sort_pump.occ` transpiles and passes `go vet`

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)