### PR TITLE
Support dotted protocol tags

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,7 +57,7 @@
 ### Protocols
 - **Simple** — `PROTOCOL SIG IS INT` (type alias)
 - **Sequential** — `PROTOCOL PAIR IS INT ; BYTE` (struct)
-- **Variant** — `PROTOCOL MSG CASE tag; TYPE ...` (interface + concrete types)
+- **Variant** — `PROTOCOL MSG CASE tag; TYPE ...` (interface + concrete types), including dotted tag names (`bar.data`, `bar.terminate`)
 
 ### Records
 - **RECORD** — Struct types with field access via bracket syntax (`p[x]`)

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -1561,7 +1561,7 @@ func (g *Generator) occamTypeToGo(occamType string) string {
 	default:
 		// Check if it's a protocol name
 		if _, ok := g.protocolDefs[occamType]; ok {
-			return "_proto_" + occamType
+			return "_proto_" + goIdent(occamType)
 		}
 		// Check if it's a record type name
 		if _, ok := g.recordDefs[occamType]; ok {

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -523,6 +523,29 @@ func TestVariantProtocolType(t *testing.T) {
 	}
 }
 
+func TestVariantProtocolDottedTags(t *testing.T) {
+	input := `PROTOCOL BAR.PROTO
+  CASE
+    bar.data; INT
+    bar.terminate
+    bar.blank; INT
+`
+	output := transpile(t, input)
+
+	if !strings.Contains(output, "type _proto_BAR_PROTO interface {") {
+		t.Errorf("expected interface declaration in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "type _proto_BAR_PROTO_bar_data struct {") {
+		t.Errorf("expected bar_data struct in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "type _proto_BAR_PROTO_bar_terminate struct{}") {
+		t.Errorf("expected bar_terminate struct in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "type _proto_BAR_PROTO_bar_blank struct {") {
+		t.Errorf("expected bar_blank struct in output, got:\n%s", output)
+	}
+}
+
 func TestRecordType(t *testing.T) {
 	input := `RECORD POINT
   INT x:

--- a/codegen/e2e_protocol_test.go
+++ b/codegen/e2e_protocol_test.go
@@ -93,6 +93,45 @@ SEQ
 	}
 }
 
+func TestE2E_VariantProtocolDottedTags(t *testing.T) {
+	// Variant protocol with dotted tag names (e.g., bar.data)
+	occam := `PROTOCOL BAR.PROTO
+  CASE
+    bar.data; INT
+    bar.terminate
+    bar.blank; INT
+
+SEQ
+  CHAN OF BAR.PROTO c:
+  INT result:
+  result := 0
+  PAR
+    SEQ
+      c ! bar.data ; 42
+      c ! bar.terminate
+    SEQ
+      c ? CASE
+        bar.data ; result
+          print.int(result)
+        bar.terminate
+          print.int(0)
+        bar.blank ; result
+          print.int(result)
+      c ? CASE
+        bar.data ; result
+          print.int(result)
+        bar.terminate
+          print.int(99)
+        bar.blank ; result
+          print.int(result)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "42\n99\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
 func TestE2E_ProtocolWithProc(t *testing.T) {
 	// Protocol channel passed as PROC parameter
 	occam := `PROTOCOL PAIR IS INT ; INT

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1684,6 +1684,64 @@ func TestVariantProtocolDecl(t *testing.T) {
 	}
 }
 
+func TestVariantProtocolDeclDottedTags(t *testing.T) {
+	input := `PROTOCOL BAR.PROTO
+  CASE
+    bar.data; INT
+    bar.terminate
+    bar.blank; INT
+`
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(program.Statements))
+	}
+
+	proto, ok := program.Statements[0].(*ast.ProtocolDecl)
+	if !ok {
+		t.Fatalf("expected ProtocolDecl, got %T", program.Statements[0])
+	}
+
+	if proto.Name != "BAR.PROTO" {
+		t.Errorf("expected name 'BAR.PROTO', got %s", proto.Name)
+	}
+
+	if proto.Kind != "variant" {
+		t.Errorf("expected kind 'variant', got %s", proto.Kind)
+	}
+
+	if len(proto.Variants) != 3 {
+		t.Fatalf("expected 3 variants, got %d", len(proto.Variants))
+	}
+
+	// bar.data; INT
+	if proto.Variants[0].Tag != "bar.data" {
+		t.Errorf("expected tag 'bar.data', got %s", proto.Variants[0].Tag)
+	}
+	if len(proto.Variants[0].Types) != 1 || proto.Variants[0].Types[0] != "INT" {
+		t.Errorf("expected types [INT] for bar.data, got %v", proto.Variants[0].Types)
+	}
+
+	// bar.terminate (no payload)
+	if proto.Variants[1].Tag != "bar.terminate" {
+		t.Errorf("expected tag 'bar.terminate', got %s", proto.Variants[1].Tag)
+	}
+	if len(proto.Variants[1].Types) != 0 {
+		t.Errorf("expected 0 types for bar.terminate, got %d", len(proto.Variants[1].Types))
+	}
+
+	// bar.blank; INT
+	if proto.Variants[2].Tag != "bar.blank" {
+		t.Errorf("expected tag 'bar.blank', got %s", proto.Variants[2].Tag)
+	}
+	if len(proto.Variants[2].Types) != 1 || proto.Variants[2].Types[0] != "INT" {
+		t.Errorf("expected types [INT] for bar.blank, got %v", proto.Variants[2].Types)
+	}
+}
+
 func TestChanDeclWithProtocol(t *testing.T) {
 	input := `PROTOCOL SIGNAL IS INT
 CHAN OF SIGNAL c:


### PR DESCRIPTION
## Summary
- Fix `occamTypeToGo()` to apply `goIdent()` on protocol names, converting dots to underscores in channel type references (e.g., `CHAN OF BAR.PROTO` → `chan _proto_BAR_PROTO` instead of broken `chan _proto_BAR.PROTO`)
- Add parser, codegen unit, and e2e tests for variant protocols with dotted tag names (`bar.data`, `bar.terminate`, `bar.blank`)
- Update TODO.md to document dotted tag name support

Closes #68

## Test plan
- [x] `go test ./parser -run TestVariantProtocolDeclDottedTags` — parser preserves dotted tag names in AST
- [x] `go test ./codegen -run TestVariantProtocolDottedTags` — codegen converts dots to underscores in type names
- [x] `go test ./codegen -run TestE2E_VariantProtocolDottedTags` — full transpile→compile→run with dotted tags (send + CASE receive, with and without payloads)
- [x] `go test ./...` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)