### PR TITLE
Fix protocol trailing colon, CASE comma values, ALT paren guards, IS continuation

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -401,6 +401,7 @@ type AltCase struct {
 	Variable     string      // variable to receive into
 	Body         []Statement // the body to execute
 	IsTimer      bool        // true if this is a timer AFTER case
+	IsSkip       bool        // true if this is a guarded SKIP case (guard & SKIP)
 	Timer        string      // timer name (when IsTimer)
 	Deadline     Expression  // AFTER deadline expression (when IsTimer)
 	Declarations []Statement // scoped declarations before channel input (e.g., BYTE ch:)

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -1764,7 +1764,7 @@ func (g *Generator) generateAltBlock(alt *ast.AltBlock) {
 	if hasGuards {
 		// Generate channel variables for guarded cases
 		for i, c := range alt.Cases {
-			if c.Guard != nil {
+			if c.Guard != nil && !c.IsSkip {
 				g.builder.WriteString(strings.Repeat("\t", g.indent))
 				g.write(fmt.Sprintf("var _alt%d chan ", i))
 				// We don't know the channel type here, so use interface{}
@@ -1782,7 +1782,9 @@ func (g *Generator) generateAltBlock(alt *ast.AltBlock) {
 	g.writeLine("select {")
 	for i, c := range alt.Cases {
 		g.builder.WriteString(strings.Repeat("\t", g.indent))
-		if c.IsTimer {
+		if c.IsSkip {
+			g.write("default:\n")
+		} else if c.IsTimer {
 			g.write("case <-time.After(time.Duration(")
 			g.generateExpression(c.Deadline)
 			g.write(" - int(time.Now().UnixMicro())) * time.Microsecond):\n")

--- a/codegen/e2e_control_test.go
+++ b/codegen/e2e_control_test.go
@@ -375,3 +375,41 @@ SEQ
 		t.Errorf("expected %q, got %q", expected, output)
 	}
 }
+
+func TestE2E_CaseCommaValues(t *testing.T) {
+	// Issue #75: comma-separated match values in CASE
+	occam := `SEQ
+  INT x:
+  x := 2
+  CASE x
+    1, 2
+      print.int(10)
+    3, 4
+      print.int(20)
+    ELSE
+      print.int(0)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "10\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_CaseCommaValuesElse(t *testing.T) {
+	// Issue #75: ELSE branch with comma-separated values
+	occam := `SEQ
+  INT x:
+  x := 5
+  CASE x
+    1, 2, 3
+      print.int(10)
+    ELSE
+      print.int(99)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "99\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}

--- a/codegen/e2e_protocol_test.go
+++ b/codegen/e2e_protocol_test.go
@@ -153,3 +153,50 @@ SEQ
 		t.Errorf("expected %q, got %q", expected, output)
 	}
 }
+
+func TestE2E_ProtocolTrailingColon(t *testing.T) {
+	// Issue #73: trailing colon on protocol declarations
+	occam := `PROTOCOL SIGNAL IS INT :
+PROTOCOL PAIR IS INT ; BOOL :
+
+SEQ
+  CHAN OF SIGNAL c:
+  INT result:
+  PAR
+    c ! 7
+    c ? result
+  print.int(result)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "7\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_VariantProtocolTrailingColon(t *testing.T) {
+	// Issue #73: trailing colon on variant protocol declarations
+	occam := `PROTOCOL MSG
+  CASE
+    data; INT
+    quit
+:
+
+SEQ
+  CHAN OF MSG c:
+  INT result:
+  result := 0
+  PAR
+    c ! data ; 55
+    c ? CASE
+      data ; result
+        print.int(result)
+      quit
+        print.int(0)
+`
+	output := transpileCompileRun(t, occam)
+	expected := "55\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -422,7 +422,8 @@ func isContinuationOp(t TokenType) bool {
 		PLUS_KW, MINUS_KW, TIMES,
 		EQ, NEQ, LT, GT, LE, GE,
 		BITAND, BITOR, BITXOR, LSHIFT, RSHIFT,
-		ASSIGN, AFTER:
+		ASSIGN, AFTER,
+		IS:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

Fixes four parsing issues discovered in `historical-examples/life.occ` (PR #71):

- **#73** — Support optional trailing `:` on protocol declarations (simple, sequential, and variant CASE forms)
- **#75** — Support comma-separated match values in CASE arms (e.g., `'q', 'Q'`) and verify ELSE support
- **#78** — Support parenthesized guard expressions in ALT (e.g., `(activity <> editing) & channel ? var`) and `guard & SKIP` (always-ready alternative)
- **#79** — Treat `IS` as a line continuation operator so multi-line abbreviations parse correctly

### Changes by package

| Package | Change |
|---------|--------|
| `lexer/` | Add `IS` to `isContinuationOp()` |
| `ast/` | Add `IsSkip` field to `AltCase` |
| `parser/` | Consume trailing colon in `parseProtocolDecl()`; loop on commas in `parseCaseStatement()`; accept `LPAREN` and handle `SKIP` in `parseAltCase()` |
| `codegen/` | Generate `default:` for SKIP ALT cases; skip nil-channel variable for SKIP guards |

## Test plan

- [x] 8 new e2e tests added covering all four fixes
- [x] Full test suite passes (`go test ./...`) with no regressions
- [x] Course module still transpiles and passes `go vet`

Closes #73, closes #75, closes #78, closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)