### PR TITLE
Support scoped declarations in variant receive case bodies

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -453,9 +453,9 @@ type VariantReceive struct {
 }
 
 type VariantCase struct {
-	Tag       string    // variant tag name
-	Variables []string  // variables to bind payload fields
-	Body      Statement
+	Tag       string      // variant tag name
+	Variables []string    // variables to bind payload fields
+	Body      []Statement // case body (may include scoped declarations)
 }
 
 func (vr *VariantReceive) statementNode()       {}

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -566,8 +566,10 @@ func (g *Generator) containsPar(stmt ast.Statement) bool {
 		}
 	case *ast.VariantReceive:
 		for _, c := range s.Cases {
-			if c.Body != nil && g.containsPar(c.Body) {
-				return true
+			for _, inner := range c.Body {
+				if g.containsPar(inner) {
+					return true
+				}
 			}
 		}
 	}
@@ -639,8 +641,10 @@ func (g *Generator) containsPrint(stmt ast.Statement) bool {
 		}
 	case *ast.VariantReceive:
 		for _, c := range s.Cases {
-			if c.Body != nil && g.containsPrint(c.Body) {
-				return true
+			for _, inner := range c.Body {
+				if g.containsPrint(inner) {
+					return true
+				}
 			}
 		}
 	}
@@ -715,8 +719,10 @@ func (g *Generator) containsTimer(stmt ast.Statement) bool {
 		}
 	case *ast.VariantReceive:
 		for _, c := range s.Cases {
-			if c.Body != nil && g.containsTimer(c.Body) {
-				return true
+			for _, inner := range c.Body {
+				if g.containsTimer(inner) {
+					return true
+				}
 			}
 		}
 	}
@@ -788,8 +794,10 @@ func (g *Generator) containsStop(stmt ast.Statement) bool {
 		}
 	case *ast.VariantReceive:
 		for _, c := range s.Cases {
-			if c.Body != nil && g.containsStop(c.Body) {
-				return true
+			for _, inner := range c.Body {
+				if g.containsStop(inner) {
+					return true
+				}
 			}
 		}
 	}
@@ -909,8 +917,10 @@ func (g *Generator) containsMostExpr(stmt ast.Statement) bool {
 		}
 	case *ast.VariantReceive:
 		for _, c := range s.Cases {
-			if c.Body != nil && g.containsMostExpr(c.Body) {
-				return true
+			for _, inner := range c.Body {
+				if g.containsMostExpr(inner) {
+					return true
+				}
 			}
 		}
 	}
@@ -1417,8 +1427,8 @@ func (g *Generator) generateVariantReceive(vr *ast.VariantReceive) {
 		for i, v := range vc.Variables {
 			g.writeLine(fmt.Sprintf("%s = _v._%d", goIdent(v), i))
 		}
-		if vc.Body != nil {
-			g.generateStatement(vc.Body)
+		for _, s := range vc.Body {
+			g.generateStatement(s)
 		}
 		g.indent--
 	}
@@ -3084,8 +3094,10 @@ func (g *Generator) walkStatements(stmt ast.Statement, fn func(ast.Expression) b
 		}
 	case *ast.VariantReceive:
 		for _, c := range s.Cases {
-			if c.Body != nil && g.walkStatements(c.Body, fn) {
-				return true
+			for _, inner := range c.Body {
+				if g.walkStatements(inner, fn) {
+					return true
+				}
 			}
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1384,12 +1384,7 @@ func (p *Parser) parseVariantReceive(channel string, token lexer.Token) *ast.Var
 		if p.peekTokenIs(lexer.INDENT) {
 			p.nextToken() // consume INDENT
 			p.nextToken() // move to body
-			vc.Body = p.parseStatement()
-
-			// Advance past the last token of the statement if needed
-			if !p.curTokenIs(lexer.NEWLINE) && !p.curTokenIs(lexer.DEDENT) && !p.curTokenIs(lexer.EOF) {
-				p.nextToken()
-			}
+			vc.Body = p.parseBodyStatements()
 		}
 
 		stmt.Cases = append(stmt.Cases, vc)
@@ -1479,11 +1474,7 @@ func (p *Parser) parseVariantReceiveWithIndex(channel string, channelIndices []a
 		if p.peekTokenIs(lexer.INDENT) {
 			p.nextToken() // consume INDENT
 			p.nextToken() // move to body
-			vc.Body = p.parseStatement()
-
-			if !p.curTokenIs(lexer.NEWLINE) && !p.curTokenIs(lexer.DEDENT) && !p.curTokenIs(lexer.EOF) {
-				p.nextToken()
-			}
+			vc.Body = p.parseBodyStatements()
 		}
 
 		stmt.Cases = append(stmt.Cases, vc)


### PR DESCRIPTION
## Summary

- Fixes #86: variant protocol receive (`ch ? CASE`) case bodies now support scoped declarations (e.g. `BOOL x:`, `INT next:`) followed by compound statements
- Changes `VariantCase.Body` from single `Statement` to `[]Statement` and uses `parseBodyStatements()`, matching the pattern already used by IF, CASE, and ALT
- Updates all 7 codegen scanner/walker functions to iterate over the body slice

## Test plan

- [x] New parser test (`TestVariantReceiveScopedDecl`) verifies multi-statement body parsing
- [x] New e2e test (`TestE2E_VariantReceiveScopedDecl`) transpiles, compiles, and runs a program with scoped declarations in variant case bodies
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)