### PR TITLE
Support receive into indexed target variables (#85)

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -373,10 +373,11 @@ func (s *Send) TokenLiteral() string { return s.Token.Literal }
 // Receive represents a channel receive: c ? x or c ? x ; y
 type Receive struct {
 	Token          lexer.Token  // the ? token
-	Channel        string       // channel name
-	ChannelIndices []Expression // non-empty for cs[i] ? x or cs[i][j] ? x
-	Variable       string       // variable to receive into (simple receive)
-	Variables      []string     // additional variables for sequential receives (c ? x ; y)
+	Channel         string       // channel name
+	ChannelIndices  []Expression // non-empty for cs[i] ? x or cs[i][j] ? x
+	Variable        string       // variable to receive into (simple receive)
+	VariableIndices []Expression // non-empty for c ? flags[0] or c ? grid[i][j]
+	Variables       []string     // additional variables for sequential receives (c ? x ; y)
 }
 
 func (r *Receive) statementNode()       {}
@@ -396,11 +397,12 @@ func (a *AltBlock) TokenLiteral() string { return a.Token.Literal }
 
 // AltCase represents a single case in an ALT block
 type AltCase struct {
-	Guard          Expression   // optional guard condition (nil if no guard)
-	Channel        string       // channel name
-	ChannelIndices []Expression // non-empty for cs[i] ? x or cs[i][j] ? x in ALT
-	Variable       string       // variable to receive into
-	Body           []Statement  // the body to execute
+	Guard           Expression   // optional guard condition (nil if no guard)
+	Channel         string       // channel name
+	ChannelIndices  []Expression // non-empty for cs[i] ? x or cs[i][j] ? x in ALT
+	Variable        string       // variable to receive into
+	VariableIndices []Expression // non-empty for c ? flags[0] or c ? grid[i][j]
+	Body            []Statement  // the body to execute
 	IsTimer        bool         // true if this is a timer AFTER case
 	IsSkip         bool         // true if this is a guarded SKIP case (guard & SKIP)
 	Timer          string       // timer name (when IsTimer)

--- a/codegen/e2e_concurrency_test.go
+++ b/codegen/e2e_concurrency_test.go
@@ -392,3 +392,41 @@ func TestE2E_PriPar(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, output)
 	}
 }
+
+func TestE2E_ReceiveIntoIndexedVariable(t *testing.T) {
+	occam := `SEQ
+  CHAN OF INT c:
+  [3]INT arr:
+  arr[0] := 0
+  arr[1] := 0
+  arr[2] := 0
+  PAR
+    c ! 42
+    c ? arr[1]
+  print.int(arr[1])
+`
+	output := transpileCompileRun(t, occam)
+	expected := "42\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}
+
+func TestE2E_IndexedChannelReceiveIntoIndexedVariable(t *testing.T) {
+	occam := `SEQ
+  [2]CHAN OF INT cs:
+  [3]INT arr:
+  arr[0] := 0
+  arr[1] := 0
+  arr[2] := 0
+  PAR
+    cs[0] ! 99
+    cs[0] ? arr[2]
+  print.int(arr[2])
+`
+	output := transpileCompileRun(t, occam)
+	expected := "99\n"
+	if output != expected {
+		t.Errorf("expected %q, got %q", expected, output)
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3888,3 +3888,93 @@ PROC test(CHAN OF CMD ch)
 		t.Errorf("expected SeqBlock as second body statement, got %T", evolveCase.Body[1])
 	}
 }
+
+func TestReceiveIndexedVariable(t *testing.T) {
+	input := `ch ? flags[0]
+`
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(program.Statements))
+	}
+
+	recv, ok := program.Statements[0].(*ast.Receive)
+	if !ok {
+		t.Fatalf("expected Receive, got %T", program.Statements[0])
+	}
+
+	if recv.Channel != "ch" {
+		t.Errorf("expected channel 'ch', got %s", recv.Channel)
+	}
+
+	if recv.Variable != "flags" {
+		t.Errorf("expected variable 'flags', got %s", recv.Variable)
+	}
+
+	if len(recv.VariableIndices) != 1 {
+		t.Fatalf("expected 1 variable index, got %d", len(recv.VariableIndices))
+	}
+}
+
+func TestReceiveMultiIndexedVariable(t *testing.T) {
+	input := `ch ? grid[i][j]
+`
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(program.Statements))
+	}
+
+	recv, ok := program.Statements[0].(*ast.Receive)
+	if !ok {
+		t.Fatalf("expected Receive, got %T", program.Statements[0])
+	}
+
+	if recv.Variable != "grid" {
+		t.Errorf("expected variable 'grid', got %s", recv.Variable)
+	}
+
+	if len(recv.VariableIndices) != 2 {
+		t.Fatalf("expected 2 variable indices, got %d", len(recv.VariableIndices))
+	}
+}
+
+func TestIndexedChannelReceiveIndexedVariable(t *testing.T) {
+	input := `cs[0] ? flags[1]
+`
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(program.Statements))
+	}
+
+	recv, ok := program.Statements[0].(*ast.Receive)
+	if !ok {
+		t.Fatalf("expected Receive, got %T", program.Statements[0])
+	}
+
+	if recv.Channel != "cs" {
+		t.Errorf("expected channel 'cs', got %s", recv.Channel)
+	}
+
+	if len(recv.ChannelIndices) != 1 {
+		t.Fatalf("expected 1 channel index, got %d", len(recv.ChannelIndices))
+	}
+
+	if recv.Variable != "flags" {
+		t.Errorf("expected variable 'flags', got %s", recv.Variable)
+	}
+
+	if len(recv.VariableIndices) != 1 {
+		t.Fatalf("expected 1 variable index, got %d", len(recv.VariableIndices))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `VariableIndices []Expression` to `Receive` and `AltCase` AST nodes, mirroring the existing `ChannelIndices` pattern
- Parse index expressions after the target variable in channel receive (`ch ? flags[0]`, `cs[i] ? grid[j][k]`) across all 5 parser sites: `parseReceive()`, `parseIndexedOperation()`, and 3 branches of `parseAltCase()`
- Generate indexed variable references in codegen across all 6 sites: `generateReceive()` (simple + sequential), `generateAltBlock()` (guarded, indexed-channel, simple-channel), and `generateReplicatedAlt()`

Closes #85

## Test plan

- [x] 3 parser unit tests: single index, multi-index, both channel and variable indexed
- [x] 2 e2e tests: `c ? arr[1]` and `cs[0] ? arr[2]` patterns
- [x] All existing tests pass (`go test ./...`)
- [x] Course module still transpiles and passes `go vet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)